### PR TITLE
Nodejs log lines

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -73,7 +73,7 @@ class Runner
       "[2021-06-14T13:59:10 (process) #53880][INFO] Starting AppSignal diagnose",
       "[2021-06-14T14:05:53 (process) #54792][INFO] Starting AppSignal diagnose",
       "[2021-06-14T14:11:37 (process) #55323][INFO] Starting AppSignal diagnose"
-    ].join("\n")
+    ].join("\n") + "\n"
   end
 
   class Ruby < Runner

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -479,16 +479,9 @@ RSpec.describe "Running the diagnose command without any arguments" do
       ])
     end
 
-    case @runner.type
-    when :ruby
-      expect_output([
-        /    Contents \(last 10 lines\):/
-      ] + Array.new(10).map { LOG_LINE_PATTERN })
-    when :nodejs
-      expect_output([
-        /    Contents \(last 9 lines\):/
-      ] + Array.new(9).map { LOG_LINE_PATTERN })
-    end
+    expect_output([
+      /    Contents \(last 10 lines\):/
+    ] + Array.new(10).map { LOG_LINE_PATTERN })
   end
 
   it "prints a newline" do

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -532,8 +532,11 @@ RSpec.describe "Running the diagnose command without any arguments" do
   LOG_LINE_PATTERN = /^(#.+|\[#{DATETIME_PATTERN} \(\w+\) \#\d+\]\[\w+\])/
 
   def expect_output(expected)
-    expected.each do |line|
-      expect(@runner.readline).to match(line)
+    actual_output = []
+    expected.each do |expected_line|
+      actual_line = @runner.readline
+      actual_output << actual_line
+      expect(actual_line).to match(expected_line), actual_output.join("\n")
     end
   end
 


### PR DESCRIPTION
Depends on #1
Build fails because the Semaphore setup is only added in #2 

## Fix Node.js log lines assertions for appsignal.log

Remove the difference between the Node.js and Ruby integrations,
printing a different number of lines. This has been fixed in the Node.js
integration.

## Always end the appsignal.log with an empty line

The log file should always end with an empty line. When it does not, the
logger will write the next line at the end of the last logged line.

```
line 1line 2
```

But because the logger will always end the log line with a line break,
our dummy log should too. The next time the logger will log a line it
will look like this instead:

```
line 1
line 2
```

## Log full actual output on expect_output failure

This will help debug the assertion failure, as you can see the full
output that was asserted again. If one line fails, the assertion failure
message can be something like `\n` didn't match `<complex regex>`.
Without the context of all lines that were asserted this can be
difficult to debug.

Update `expect_output` helper to print the full actual output that was
asserted against (so far) on failure.

