### PR TITLE
Add RuboCop linting to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+tmp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,66 @@
+AllCops:
+  DisplayCopNames: true
+  UseCache: true
+  CacheRootDirectory: ./tmp
+  NewCops: enable
+
+Style/Documentation:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Layout/HashAlignment:
+  EnforcedLastArgumentHashStyle: ignore_implicit
+
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/LineEndStringConcatenationIndentation:
+  EnforcedStyle: indented
+
+Layout/LineLength:
+  Max: 100
+
+Style/Lambda:
+  EnforcedStyle: lambda
+
+Style/WordArray:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - Rakefile
+    - "**/spec/*.rb"
+
+Metrics/MethodLength:
+  Max: 25
+  Exclude:
+    - Rakefile

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,6 +15,12 @@ blocks:
         commands:
           - checkout
       jobs:
+        - name: Ruby Lint (RuboCop)
+          commands:
+            - cache restore
+            - bundle install
+            - cache store
+            - bundle exec rubocop
         - name: Git Lint (Lintje)
           env_vars:
             - name: LINTJE_VERSION

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "rack"
 gem "rspec"
+gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     diff-lcs (1.4.4)
+    parallel (1.20.1)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
     rack (2.2.3)
+    rainbow (3.0.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -16,6 +23,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
+    rubocop (1.18.4)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.8.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.9.0)
+      parser (>= 3.0.1.1)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
@@ -23,6 +43,7 @@ PLATFORMS
 DEPENDENCIES
   rack
   rspec
+  rubocop
 
 BUNDLED WITH
-   2.1.4
+   2.2.17

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "appsignal", :path => "../../../../"


### PR DESCRIPTION
Do not rely on the appsignal-ruby RuboCop, but instead add our own. This
way we can also use a more recent RuboCop version.

I also fixed any issues that arose. Some parts automatically corrected
by RuboCop, some required a manual touch.