### PR TITLE
Fix the Node.js install report location

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -12,9 +12,11 @@ class Runner
 
   def run(arguments = nil)
     Dir.chdir(directory)
+    before_setup
     setup_commands.each do |command|
       run_setup command
     end
+    after_setup
     @pid = spawn(
       { "APPSIGNAL_PUSH_API_KEY" => "test" },
       [run_command, arguments].compact.join(" "),
@@ -63,7 +65,11 @@ class Runner
     logger
   end
 
-  def prepare
+  def before_setup
+    # Placeholder
+  end
+
+  def after_setup
     # Placeholder
   end
 
@@ -113,7 +119,12 @@ class Runner
       "Ruby"
     end
 
-    def prepare
+    def before_setup
+      # Placeholder
+    end
+
+    def after_setup
+      # Overwite created install report so we have a consistent test environment
       File.write(File.join(__dir__, "../../../../ext/install.report"), install_report)
       File.write("/tmp/appsignal.log", appsignal_log)
     end
@@ -208,7 +219,12 @@ class Runner
       "Node.js"
     end
 
-    def prepare
+    def before_setup
+      # Placeholder
+    end
+
+    def after_setup
+      # Overwite created install report so we have a consistent test environment
       File.write("/tmp/appsignal-install-report.json", install_report)
       File.write("/tmp/appsignal.log", appsignal_log)
     end
@@ -258,8 +274,6 @@ RSpec.describe "Running the diagnose command without any arguments" do
       "elixir" => Runner::Elixir.new,
       "nodejs" => Runner::Nodejs.new
     }[language]
-
-    @runner.prepare
     @runner.run
   end
 
@@ -561,7 +575,6 @@ RSpec.describe "Running the diagnose command with the --no-send-report option" d
       "nodejs" => Runner::Nodejs.new
     }[language]
 
-    @runner.prepare
     @runner.run("--no-send-report")
   end
 

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -2,6 +2,7 @@
 
 require "logger"
 require "timeout"
+require "digest"
 
 class Runner
   include Enumerable
@@ -225,7 +226,10 @@ class Runner
 
     def after_setup
       # Overwite created install report so we have a consistent test environment
-      File.write("/tmp/appsignal-install-report.json", install_report)
+      package_path = "#{File.expand_path("../../../../../", __dir__)}/"
+      report_path_digest = Digest::SHA256.hexdigest(package_path)
+
+      File.write("/tmp/appsignal-#{report_path_digest}-install.report", install_report)
       File.write("/tmp/appsignal.log", appsignal_log)
     end
 


### PR DESCRIPTION
## Fix the Node.js install report location

### Background

The Node.js integration's install report is now stored with a more
unique filename based on the app install path. This way it doesn't
overwrite the install report if multiple apps on the same host use the
AppSignal package.

appsignal/appsignal-nodejs#412

### Problem

The diagnose tests wrote the install report to an outdated location and
thus wasn't actually used by the diagnose tests. This came to light when
changing the install script of the Node.js integration to always write
an install report, also for local installs. This change has not been
merged at time of writing, but highlighted this issue that is a problem
now. Previously it worked accidentally because the installer wrote a new
report upon installation and that happened to match the expected ouput.

### Solution

Adapt the new naming scheme as introduced in the previously linked
Node.js integration PR, but this time in Ruby.

Closes #7

---

Other refactors

## Replace prepare step with callbacks

The prepare step can be split up into before and after setup callbacks.
This gives more control when exactly the setup is happening.

This is useful and possible necessary for the Node.js integration at
least, since the setup commands may overwrite the install report (as it
runs the installer itself). I'm in the process of potentially rewriting
the install script for Node.js to not skip writing an install report for
local installations, meaning the installer will always write a report.
If it does we need to overwrite the install report after the
installation again.

Since the before and after callbacks need to be run in very precise
steps along with the rest of the setup, remove the explicit `prepare`
call from the runners.

