### PR TITLE
Test missing install report

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -316,3 +316,21 @@ RSpec.describe "Running the diagnose command with the --no-send-report option" d
     )
   end
 end
+
+RSpec.describe "Running the diagnose command without install report file" do
+  before do
+    @runner = init_runner(:install_report => false)
+    @runner.run
+  end
+
+  it "prints handled errors instead of the report" do
+    expect_section(
+      :installation,
+      [
+        "Extension installation report",
+        "  Error found while parsing the report.",
+        /^  Error: .* [nN]o such file or directory.*install\.report/
+      ]
+    )
+  end
+end

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -14,12 +14,7 @@ LOG_LINE_PATTERN = /^(#.+|\[#{DATETIME_PATTERN} \(\w+\) \#\d+\]\[\w+\])/.freeze
 
 RSpec.describe "Running the diagnose command without any arguments" do
   before(:all) do
-    language = ENV["LANGUAGE"] || "ruby"
-    @runner = {
-      "ruby" => Runner::Ruby.new,
-      "elixir" => Runner::Elixir.new,
-      "nodejs" => Runner::Nodejs.new
-    }[language]
+    @runner = init_runner
     @runner.run
   end
 
@@ -309,13 +304,7 @@ end
 
 RSpec.describe "Running the diagnose command with the --no-send-report option" do
   before do
-    language = ENV["LANGUAGE"] || "ruby"
-    @runner = {
-      "ruby" => Runner::Ruby.new,
-      "elixir" => Runner::Elixir.new,
-      "nodejs" => Runner::Nodejs.new
-    }[language]
-
+    @runner = init_runner
     @runner.run("--no-send-report")
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "support/runner"
+require_relative "support/runner_helper"
 require_relative "support/output_helper"
 
 RSpec.configure do |config|
   config.include OutputHelper
+  config.include RunnerHelper
 
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -77,6 +77,14 @@ class Runner
     end
   end
 
+  def initialize(options = {})
+    @options = options
+  end
+
+  def install_report?
+    @options.fetch(:install_report, true)
+  end
+
   def run(arguments = nil)
     Dir.chdir directory do
       before_setup
@@ -181,8 +189,13 @@ class Runner
     end
 
     def after_setup
-      # Overwite created install report so we have a consistent test environment
-      File.write(File.join(__dir__, "../../../../../ext/install.report"), install_report)
+      install_report_path = File.join(__dir__, "../../../../../ext/install.report")
+      if install_report?
+        # Overwite created install report so we have a consistent test environment
+        File.write(install_report_path, install_report)
+      elsif File.exist?(install_report_path)
+        File.delete(install_report_path)
+      end
       File.write("/tmp/appsignal.log", appsignal_log)
     end
 
@@ -285,7 +298,12 @@ class Runner
       package_path = "#{File.expand_path("../../../../../../", __dir__)}/"
       report_path_digest = Digest::SHA256.hexdigest(package_path)
 
-      File.write("/tmp/appsignal-#{report_path_digest}-install.report", install_report)
+      install_report_path = "/tmp/appsignal-#{report_path_digest}-install.report"
+      if install_report?
+        File.write(install_report_path, install_report)
+      elsif File.exist?(install_report_path)
+        File.delete(install_report_path)
+      end
       File.write("/tmp/appsignal.log", appsignal_log)
     end
 

--- a/spec/support/runner_helper.rb
+++ b/spec/support/runner_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RunnerHelper
+  LANGUAGE_RUNNERS = {
+    "ruby" => Runner::Ruby,
+    "elixir" => Runner::Elixir,
+    "nodejs" => Runner::Nodejs
+  }.freeze
+
+  def init_runner
+    language = ENV.fetch("LANGUAGE") { raise "No LANGUAGE environment variable is configured" }
+    runner_class = LANGUAGE_RUNNERS.fetch(language) do
+      raise "No runner found for language: `#{language}`"
+    end
+    runner_class.new
+  end
+end

--- a/spec/support/runner_helper.rb
+++ b/spec/support/runner_helper.rb
@@ -7,11 +7,11 @@ module RunnerHelper
     "nodejs" => Runner::Nodejs
   }.freeze
 
-  def init_runner
+  def init_runner(options = {})
     language = ENV.fetch("LANGUAGE") { raise "No LANGUAGE environment variable is configured" }
     runner_class = LANGUAGE_RUNNERS.fetch(language) do
       raise "No runner found for language: `#{language}`"
     end
-    runner_class.new
+    runner_class.new(options)
   end
 end


### PR DESCRIPTION
Based on #13 
Required for https://github.com/appsignal/appsignal-nodejs/pull/454

## Add runner helper for tests

Don't fetch and initialize the runner instance in every test itself, but
add a helper for it with additional error handling.

I removed the "ruby" default, because it burned me a couple times when I
hadn't set the LANGUAGE environment variable. It's better to just have
it error when that happens and have all integrations behave the same.

## Test missing install report

When no agent and extension install report is present on the file
system, test if the diagnose command prints the error correctly.

To communicate to the runner that the install report should be created I
added an options argument to the Runner class, which can be expanded
with other future options.

