### PR TITLE
Update config test for Elixir

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -233,6 +233,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  dns_servers: \[\]/,
         /  enable_host_metrics: true/,
         /  enable_minutely_probes: true/,
+        /  enable_statsd: false/,
         /  endpoint: #{quoted "https://push.appsignal.com"}/,
         /  env: "dev"/,
         /  files_world_accessible: true/,


### PR DESCRIPTION
Add enable_statsd config option to the Configuration section for the
Elixir integration library.

[skip review]