### PR TITLE
Enable Agent diagnose tests for Node.js

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -391,3 +391,32 @@ RSpec.describe "Running the diagnose command without install report file" do
     expect_section(:installation, matchers)
   end
 end
+
+RSpec.describe "Running the diagnose command without Push API key" do
+  before do
+    @runner = init_runner(:push_api_key => "", :prompt => "n")
+    @runner.run
+  end
+
+  it "prints agent diagnose section with errors" do
+    expect_section(
+      :agent,
+      [
+        /Agent diagnostics/,
+        /  Extension tests/,
+        /  Configuration: invalid/,
+        /     Error: RequiredEnvVarNotPresent\("_APPSIGNAL_PUSH_API_KEY"\)/,
+        /  Agent tests/,
+        /    Started: -/,
+        /    Process user id: -/,
+        /    Process user group id: -/,
+        /    Configuration: -/,
+        /    Logger: -/,
+        /    Working directory user id: -/,
+        /    Working directory user group id: -/,
+        /    Working directory permissions: -/,
+        /    Lock path: -/
+      ]
+    )
+  end
+end

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -81,6 +81,7 @@ class Runner
     @prompt = options.delete(:prompt)
     @arguments = options.delete(:args) { [] }
     @options = options
+    @push_api_key = options.fetch(:push_api_key, "test")
   end
 
   def install_report?
@@ -101,7 +102,7 @@ class Runner
     command = run_command
     read, write = IO.pipe
     pid = spawn(
-      { "APPSIGNAL_PUSH_API_KEY" => "test" },
+      { "APPSIGNAL_PUSH_API_KEY" => @push_api_key },
       "#{prompt} #{command}",
       { [:out, :err] => write, :chdir => directory }
     )


### PR DESCRIPTION
Remove exceptions for different integrations. The diagnose report now
all contain the same sections.

Needed by https://github.com/appsignal/appsignal-nodejs/pull/467