### PR TITLE
Submit diagnose reports to spec server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "pry"
 gem "rack"
+gem "sinatra"
 gem "rspec"
 gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,8 @@ GEM
     coderay (1.1.3)
     diff-lcs (1.4.4)
     method_source (1.0.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -12,6 +14,8 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
     rainbow (3.0.0)
     regexp_parser (2.1.1)
     rexml (3.2.5)
@@ -40,6 +44,13 @@ GEM
     rubocop-ast (1.9.0)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    tilt (2.0.10)
     unicode-display_width (2.0.0)
 
 PLATFORMS
@@ -50,6 +61,7 @@ DEPENDENCIES
   rack
   rspec
   rubocop
+  sinatra
 
 BUNDLED WITH
    2.2.17

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -7,6 +7,7 @@ TARGET_PATTERN = /(darwin\d*|linux(-gnu|-musl)?|freebsd)/.freeze
 LIBRARY_TYPE_PATTERN = /static|dynamic/.freeze
 TAR_FILENAME_PATTERN =
   /appsignal-#{ARCH_PATTERN}-#{TARGET_PATTERN}-all-#{LIBRARY_TYPE_PATTERN}.tar.gz/.freeze
+DOWNLOAD_URL = %r{https://appsignal-agent-releases.global.ssl.fastly.net/#{REVISION_PATTERN}/#{TAR_FILENAME_PATTERN}}.freeze
 DATETIME_PATTERN = /\d{4}-\d{2}-\d{2}[ |T]\d{2}:\d{2}:\d{2}( ?UTC|.\d+Z)?/.freeze
 TRUE_OR_FALSE_PATTERN = /true|false/.freeze
 PATH_PATTERN = %r{[/\w.-]+}.freeze
@@ -14,8 +15,9 @@ LOG_LINE_PATTERN = /^(#.+|\[#{DATETIME_PATTERN} \(\w+\) \#\d+\]\[\w+\])/.freeze
 
 RSpec.describe "Running the diagnose command without any arguments" do
   before(:all) do
-    @runner = init_runner(:prompt => "n")
+    @runner = init_runner(:prompt => "y")
     @runner.run
+    @received_report = DiagnoseServer.last_received_report
   end
 
   it "prints all sections in the correct order" do
@@ -32,6 +34,20 @@ RSpec.describe "Running the diagnose command without any arguments" do
         :send_report
       ]
     expect(@runner.output.sections.keys).to eq(section_keys), @runner.output.to_s
+  end
+
+  it "submitted report contains all keys" do
+    expect(@received_report.to_h.keys).to contain_exactly(
+      "agent",
+      "app",
+      "config",
+      "host",
+      "installation",
+      "library",
+      "paths",
+      "process",
+      "validation"
+    )
   end
 
   it "prints no 'other' section" do
@@ -65,6 +81,16 @@ RSpec.describe "Running the diagnose command without any arguments" do
     )
   end
 
+  it "submitted report contains library section" do
+    expect_report_for(
+      :library,
+      "language" => @runner.type.to_s,
+      "agent_version" => REVISION_PATTERN,
+      "package_version" => VERSION_PATTERN,
+      "extension_loaded" => true
+    )
+  end
+
   it "prints the extension installation section" do
     matchers = [
       "Extension installation report",
@@ -78,7 +104,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
 
     matchers += [
       /  Download details/,
-      /    Download URL: #{quoted %r{https://appsignal-agent-releases.global.ssl.fastly.net/#{REVISION_PATTERN}/#{TAR_FILENAME_PATTERN}}}/
+      /    Download URL: #{quoted DOWNLOAD_URL}/
     ]
 
     if @runner.type == :elixir
@@ -116,6 +142,34 @@ RSpec.describe "Running the diagnose command without any arguments" do
     expect_output_for(:installation, matchers)
   end
 
+  it "submitted report contains extension installation section" do
+    expect_report_for(
+      :installation,
+      "result" => { "status" => "success" },
+      "language" => {
+        "name" => @runner.type.to_s,
+        "version" => VERSION_PATTERN,
+        "implementation" => be_kind_of(String)
+      },
+      "download" => {
+        "checksum" => "verified",
+        "download_url" => DOWNLOAD_URL
+      },
+      "build" => {
+        "time" => DATETIME_PATTERN,
+        "architecture" => ARCH_PATTERN,
+        "target" => TARGET_PATTERN,
+        "musl_override" => false,
+        "linux_arm_override" => false,
+        "library_type" => "static"
+      },
+      "host" => {
+        "dependencies" => {},
+        "root_user" => false
+      }
+    )
+  end
+
   it "prints the host information section" do
     architecture =
       if @runner.type == :elixir
@@ -137,6 +191,18 @@ RSpec.describe "Running the diagnose command without any arguments" do
     expect_output_for(:host, matchers)
   end
 
+  it "submitted report contains host section" do
+    expect_report_for(
+      :host,
+      "architecture" => ARCH_PATTERN,
+      "heroku" => false,
+      "language_version" => VERSION_PATTERN,
+      "os" => TARGET_PATTERN,
+      "root" => false,
+      "running_in_container" => boolean
+    )
+  end
+
   it "prints the agent diagnostics section" do
     expect_output_for(
       :agent,
@@ -155,6 +221,40 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /    Working directory permissions: \d+/,
         /    Lock path: writable/
       ]
+    )
+  end
+
+  it "submitted report contains agent diagnostics section" do
+    expect_report_for(
+      :agent,
+      "agent" => {
+        "boot" => {
+          "started" => { "result" => true }
+        },
+        "config" => {
+          "valid" => { "result" => true }
+        },
+        "host" => {
+          "gid" => { "result" => kind_of(Numeric) },
+          "uid" => { "result" => kind_of(Numeric) }
+        },
+        "lock_path" => {
+          "created" => { "result" => true }
+        },
+        "logger" => {
+          "started" => { "result" => true }
+        },
+        "working_directory_stat" => {
+          "gid" => { "result" => kind_of(Numeric) },
+          "mode" => { "result" => kind_of(Numeric) },
+          "uid" => { "result" => kind_of(Numeric) }
+        }
+      },
+      "extension" => {
+        "config" => {
+          "valid" => { "result" => true }
+        }
+      }
     )
   end
 
@@ -244,6 +344,33 @@ RSpec.describe "Running the diagnose command without any arguments" do
     expect_output_for(:config, matchers)
   end
 
+  it "submitted report contains configuration section" do
+    expected_report_section =
+      case @runner.type
+      when :ruby, :elixir
+        # TODO
+        raise "Report matchers missing"
+      when :nodejs
+        {
+          "options" => {
+            "active" => true,
+            "ca_file_path" => ending_with("cert/cacert.pem"),
+            "debug" => false,
+            "endpoint" => "https://push.appsignal.com",
+            "env" => "test",
+            "log" => "file",
+            "log_path" => "/tmp",
+            "push_api_key" => "test",
+            "undefined" => "/tmp/appsignal.log" # TODO: Fix in integration: https://github.com/appsignal/appsignal-nodejs/issues/472
+          },
+          "sources" => {} # TODO: Fix in integration: https://github.com/appsignal/appsignal-nodejs/issues/473
+        }
+      else
+        raise "No clause for runner #{@runner}"
+      end
+    expect_report_for(:config, expected_report_section)
+  end
+
   it "prints the validation section" do
     expect_output_for(
       :validation,
@@ -251,6 +378,13 @@ RSpec.describe "Running the diagnose command without any arguments" do
         "Validation",
         /  Validating Push API key: (\e\[31m)?invalid(\e\[0m)?/
       ]
+    )
+  end
+
+  it "submitted report contains validation section" do
+    expect_report_for(
+      :validation,
+      "push_api_key" => "invalid"
     )
   end
 
@@ -331,7 +465,91 @@ RSpec.describe "Running the diagnose command without any arguments" do
     expect_output_for(:paths, matchers)
   end
 
+  it "submitted report contains paths section" do
+    matchers =
+      case @runner.type
+      when :nodejs
+        {
+          "appsignal.log" => {
+            "content" => including(
+              "[2021-06-14T13:44:22 (process) #49713][INFO] Starting AppSignal diagnose",
+              "[2021-06-14T13:50:02 (process) #51074][INFO] Starting AppSignal diagnose",
+              "[2021-06-14T13:51:54 (process) #51823][INFO] Starting AppSignal diagnose",
+              "[2021-06-14T13:52:07 (process) #52200][INFO] Starting AppSignal diagnose",
+              "[2021-06-14T13:53:03 (process) #52625][INFO] Starting AppSignal diagnose",
+              "[2021-06-14T13:55:20 (process) #53396][INFO] Starting AppSignal diagnose",
+              "[2021-06-14T13:59:10 (process) #53880][INFO] Starting AppSignal diagnose",
+              "[2021-06-14T14:05:53 (process) #54792][INFO] Starting AppSignal diagnose",
+              "[2021-06-14T14:11:37 (process) #55323][INFO] Starting AppSignal diagnose"
+            ),
+            "exists" => true,
+            "mode" => kind_of(Numeric),
+            "ownership" => {
+              "gid" => kind_of(Numeric),
+              "uid" => kind_of(Numeric)
+            },
+            "path" => "/tmp/appsignal.log",
+            "type" => "file",
+            "writable" => true
+          },
+          "log_dir_path" => {
+            "exists" => true,
+            "mode" => kind_of(Numeric),
+            "ownership" => {
+              "gid" => kind_of(Numeric),
+              "uid" => kind_of(Numeric)
+            },
+            "path" => "/tmp",
+            "type" => "directory",
+            "writable" => true
+          },
+          "working_dir" => {
+            "exists" => true,
+            "mode" => kind_of(Numeric),
+            "ownership" => {
+              "gid" => kind_of(Numeric),
+              "uid" => kind_of(Numeric)
+            },
+            "path" => match(PATH_PATTERN),
+            "type" => "directory",
+            "writable" => true
+          }
+        }
+      when :ruby, :elixir
+        # TODO
+        raise "Report matchers missing"
+      else
+        raise "No match found for runner #{@runner.type}"
+      end
+    expect_report_for(:paths, matchers)
+  end
+
   it "prints the diagnostics report section" do
+    expect_output_for(
+      :send_report,
+      [
+        "Diagnostics report",
+        "  Do you want to send this diagnostics report to AppSignal?",
+        "  If you share this report you will be given a link to",
+        "  AppSignal.com to validate the report.",
+        "  You can also contact us at support@appsignal.com",
+        "  with your support token.",
+        "",
+        "  Send diagnostics report to AppSignal? (Y/n):   Your support token: diag_support_token",
+        "  View this report: https://appsignal.com/diagnose/diag_support_token"
+      ]
+    )
+  end
+end
+
+RSpec.describe "Running the diagnose command and not submitting report" do
+  before :all do
+    @runner = init_runner(:prompt => "n")
+    @runner.run
+    @received_report = DiagnoseServer.last_received_report
+  end
+
+  it "does not ask to send the report" do
     expect_output_for(
       :send_report,
       [
@@ -347,12 +565,38 @@ RSpec.describe "Running the diagnose command without any arguments" do
       ]
     )
   end
+
+  it "does not submit a report" do
+    expect(@received_report).to be_nil
+  end
+end
+
+RSpec.describe "Running the diagnose command with the --send-report option" do
+  before :all do
+    @runner = init_runner(:args => ["--send-report"])
+    @runner.run
+    @received_report = DiagnoseServer.last_received_report
+  end
+
+  it "sends the report automatically" do
+    send_report = section(:send_report)
+    expect(send_report).to_not include("Send diagnostics report to AppSignal?")
+    expect(send_report).to include(
+      "  Your support token: diag_support_token",
+      "  View this report: https://appsignal.com/diagnose/diag_support_token"
+    )
+  end
+
+  it "submit a report automatically" do
+    expect(@received_report).to be_instance_of(DiagnoseReport)
+  end
 end
 
 RSpec.describe "Running the diagnose command with the --no-send-report option" do
-  before do
+  before :all do
     @runner = init_runner(:args => ["--no-send-report"])
     @runner.run
+    @received_report = DiagnoseServer.last_received_report
   end
 
   it "does not ask to send the report" do
@@ -362,12 +606,17 @@ RSpec.describe "Running the diagnose command with the --no-send-report option" d
       "Not sending report. (Specified with the --no-send-report option.)"
     )
   end
+
+  it "does not submit a report" do
+    expect(@received_report).to be_nil
+  end
 end
 
 RSpec.describe "Running the diagnose command without install report file" do
-  before do
-    @runner = init_runner(:install_report => false, :prompt => "n")
+  before :all do
+    @runner = init_runner(:install_report => false, :prompt => "y")
     @runner.run
+    @received_report = DiagnoseServer.last_received_report
   end
 
   it "prints handled errors instead of the report" do
@@ -391,12 +640,32 @@ RSpec.describe "Running the diagnose command without install report file" do
 
     expect_output_for(:installation, matchers)
   end
+
+  it "submitted report contains install report errors" do
+    matchers =
+      case @runner.type
+      when :ruby, :nodejs
+        {
+          "parsing_error" => {
+            "backtrace" => kind_of(Array),
+            "error" => match(/Error: ENOENT: [nN]o such file or directory.*install\.report/)
+          }
+        }
+      when :elixir
+        # TODO
+        raise "Report matchers missing"
+      else
+        raise "No clause for runner #{@runner}"
+      end
+    expect_report_for(:installation, matchers)
+  end
 end
 
 RSpec.describe "Running the diagnose command without Push API key" do
-  before do
-    @runner = init_runner(:push_api_key => "", :prompt => "n")
+  before :all do
+    @runner = init_runner(:push_api_key => "", :prompt => "y")
     @runner.run
+    @received_report = DiagnoseServer.last_received_report
   end
 
   it "prints agent diagnose section with errors" do
@@ -419,5 +688,28 @@ RSpec.describe "Running the diagnose command without Push API key" do
         /    Lock path: -/
       ]
     )
+  end
+
+  it "submitted report contains agent diagnostics errors" do
+    matchers =
+      case @runner.type
+      when :nodejs
+        {
+          "extension" => {
+            "config" => {
+              "valid" => {
+                "error" => "RequiredEnvVarNotPresent(\"_APPSIGNAL_PUSH_API_KEY\")",
+                "result" => false
+              }
+            }
+          }
+        }
+      when :ruby, :elixir
+        # TODO
+        raise "Report matchers missing"
+      else
+        raise "No clause for runner #{@runner}"
+      end
+    expect_report_for(:agent, matchers)
   end
 end

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
   end
 
   it "prints the library section" do
-    expect_section(
+    expect_output_for(
       :library,
       [
         /AppSignal library/,
@@ -113,7 +113,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
       /  Host details/,
       /    Root user: #{TRUE_OR_FALSE_PATTERN}/
     ]
-    expect_section(:installation, matchers)
+    expect_output_for(:installation, matchers)
   end
 
   it "prints the host information section" do
@@ -134,11 +134,11 @@ RSpec.describe "Running the diagnose command without any arguments" do
       /  Root user: #{TRUE_OR_FALSE_PATTERN}/,
       /  Running in container: #{TRUE_OR_FALSE_PATTERN}/
     ]
-    expect_section(:host, matchers)
+    expect_output_for(:host, matchers)
   end
 
   it "prints the agent diagnostics section" do
-    expect_section(
+    expect_output_for(
       :agent,
       [
         /Agent diagnostics/,
@@ -241,11 +241,11 @@ RSpec.describe "Running the diagnose command without any arguments" do
       "Read more about how the diagnose config output is rendered",
       "https://docs.appsignal.com/#{@runner.type}/command-line/diagnose.html"
     ]
-    expect_section(:config, matchers)
+    expect_output_for(:config, matchers)
   end
 
   it "prints the validation section" do
-    expect_section(
+    expect_output_for(
       :validation,
       [
         "Validation",
@@ -328,11 +328,11 @@ RSpec.describe "Running the diagnose command without any arguments" do
       /    Contents \(last 10 lines\):/
     ] + Array.new(10).map { LOG_LINE_PATTERN })
 
-    expect_section(:paths, matchers)
+    expect_output_for(:paths, matchers)
   end
 
   it "prints the diagnostics report section" do
-    expect_section(
+    expect_output_for(
       :send_report,
       [
         "Diagnostics report",
@@ -389,7 +389,7 @@ RSpec.describe "Running the diagnose command without install report file" do
       raise "No match found for runner #{@runner.type}"
     end
 
-    expect_section(:installation, matchers)
+    expect_output_for(:installation, matchers)
   end
 end
 
@@ -400,7 +400,7 @@ RSpec.describe "Running the diagnose command without Push API key" do
   end
 
   it "prints agent diagnose section with errors" do
-    expect_section(
+    expect_output_for(
       :agent,
       [
         /Agent diagnostics/,

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe "Running the diagnose command without any arguments" do
   it "submitted report contains all keys" do
     expect(@received_report.to_h.keys).to contain_exactly(
       "agent",
-      "app",
       "config",
       "host",
       "installation",

--- a/spec/support/diagnose_report_helper.rb
+++ b/spec/support/diagnose_report_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DiagnoseReportHelper
+  def expect_report_for(section_key, expected)
+    unless @received_report
+      raise "expect_report_for: No @received_report found, is `#{@received_report.inspect}`"
+    end
+
+    section = @received_report.section(section_key.to_s)
+    expect(section).to match(expected)
+  end
+end

--- a/spec/support/output_helper.rb
+++ b/spec/support/output_helper.rb
@@ -5,7 +5,7 @@ module OutputHelper
     @runner.output.section(key)
   end
 
-  def expect_section(section_key, expected)
+  def expect_output_for(section_key, expected)
     actual_section = section(section_key)
     section_lines = actual_section.split("\n")
     unless section_lines.length == expected.length

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -39,7 +39,7 @@ class DiagnoseServer < Sinatra::Base
         if request
           DiagnoseReport.new(
             :params => request.params,
-            :report => JSON.parse(request.body.read)
+            :report => JSON.parse(request.body.read)["diagnose"]
           )
         end
       end

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "sinatra/base"
+
+class DiagnoseReport
+  attr_reader :params
+
+  def initialize(params: {}, report: {})
+    @params = params
+    @report = report
+  end
+
+  def section(key)
+    @report.fetch(key.to_s) { raise "No `#{key}` key found in the DiagnoseReport" }
+  end
+
+  def to_h
+    @report
+  end
+end
+
+class DiagnoseServer < Sinatra::Base
+  class << self
+    def run!(port)
+      @mutex = Mutex.new
+      @received_requests = []
+      super(:port => port)
+    end
+
+    def track_request(request)
+      @mutex.synchronize do
+        @received_requests << request
+      end
+    end
+
+    def last_received_report
+      @mutex.synchronize do
+        request = @received_requests.last
+        if request
+          DiagnoseReport.new(
+            :params => request.params,
+            :report => JSON.parse(request.body.read)
+          )
+        end
+      end
+    end
+
+    def clear!
+      @mutex.synchronize do
+        @received_requests.clear
+      end
+    end
+  end
+
+  set :logging, false
+
+  post "/diag" do
+    DiagnoseServer.track_request(request)
+    status 200
+    JSON.dump({ :token => "diag_support_token" })
+  end
+end


### PR DESCRIPTION
Part of https://github.com/appsignal/integration-guide/issues/59

---

## Rename expect_section helper

Rename the expect_section to expect_output_for. This name is more clear,
it asserts the output of the runner, for a specific section.

## Submit diagnose reports to spec server

To test the diagnose reports for all integrations, submit the reports
from the integrations to a mock server for the test suite.

This mock server will receive the report and parse the JSON. Then we can
use that parsed report to test on it in the diagnose tests.

### Changes to the specs

I've added separate specs for report structure and values. I didn't want
to mix them in the output specs even though they test the same values,
but I don't want to spec to fail if only the output or the report is
wrong.

I've added a new `expect_report_for` helper to test the report itself,
but this is not done yet, as it doesn't make sure that the entire report
section structure matches.

The specs now submit the diagnose report by default, and we have
separate tests for what happens when we don't. This makes it easier to
test the report values along side the output specs.

### Changes to the integrations

To have the integrations submit to this mock server, they need to be
configured with a new server endpoint. I've done this with the
`APPSIGNAL_DIAGNOSE_ENDPOINT` environment variable. The integrations
will need to be updated to listen to this environment variable and use
its value as an endpoint instead of the default `appsignal.com/diag`.

### Output to STDOUT

The diagnose specs now log Sinatra requests (from the mock server) to
STDOUT. I've already set `logging` to `false`, but it still logs some
information. Not sure how to disable that.

## Remove app section from diagnose report

No integrations include an app section with anything in it. Only the
Node.js integration sends an empty object for this section, so I'm
removing it.

## Fetch the report from nested diagnose key

The diagnose CLIs in the Ruby and Elixir integrations wrap the diagnose
report in a "diagnose" key. This is because of how the Rails endpoint
was originally written.

Update the diagnose tests, which were originally written against the
Node.js integration, to fetch the report from the nested diagnose key.
I've updated the Node.js integration to match.

