### PR TITLE
Update diagnose specs to match Ruby gem format

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../..
   specs:
-    appsignal (3.0.4)
+    appsignal (3.0.14)
       rack
 
 GEM
@@ -16,4 +16,4 @@ DEPENDENCIES
   appsignal!
 
 BUNDLED WITH
-   2.1.4
+   2.2.17

--- a/spec/support/diagnose_report_helper.rb
+++ b/spec/support/diagnose_report_helper.rb
@@ -9,4 +9,16 @@ module DiagnoseReportHelper
     section = @received_report.section(section_key.to_s)
     expect(section).to match(expected)
   end
+
+  def path_ownership(runner_type)
+    {
+      "gid" => kind_of(Numeric),
+      "uid" => kind_of(Numeric)
+    }.tap do |hash|
+      if runner_type == :ruby
+        hash["group"] = kind_of(String)
+        hash["user"] = kind_of(String)
+      end
+    end
+  end
 end

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -214,6 +214,7 @@ class Runner
         result:
           status: success
         language:
+          name: ruby
           implementation: ruby
           version: 2.7.0-p83
         download:

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -419,7 +419,10 @@ class Runner
             "target": "darwin",
             "musl_override": false,
             "linux_arm_override": false,
-            "library_type": "static"
+            "library_type": "static",
+            "flags": {},
+            "dependencies": {},
+            "source": "remote"
           },
           "host": {
             "root_user": false,


### PR DESCRIPTION
## Update diagnose specs to match Ruby gem format

I consider the Ruby gem leading in most of the data that the report
includes, so I've updated it to expect the Ruby gem's format.

The other integrations will need to match it. The only exception I know
is the `user` and `group` keys for path ownership, it's not easy to get
these in all languages, so they're only required for the Ruby gem.


## Update Node.js install report

The report stub we use didn't include some fields the integration
does write to the report file.

