### PR TITLE
Elixir diagnose specs updates

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -336,7 +336,6 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /      system:  true/,
         /  ca_file_path: #{quoted ".+/_build/dev/rel/elixir_diagnose/lib/appsignal-\\d+\\.\\d+\\.\\d+/priv/cacert.pem"}/, # rubocop:disable Layout/LineLength
         /  debug: false/,
-        /  diagnose_endpoint: #{quoted "https://appsignal.com/diag"}/,
         /  dns_servers: \[\]/,
         /  enable_host_metrics: true/,
         /  enable_minutely_probes: true/,

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -335,7 +335,9 @@ class Runner
             "package_path": "/appsignal-elixir/_build/dev/lib/appsignal/priv",
             "source": "remote",
             "target": "darwin",
-            "time": "2021-10-19T08:35:03.854017Z"
+            "time": "2021-10-19T08:35:03.854017Z",
+            "dependencies": {},
+            "flags": {}
           },
           "download": {
             "checksum": "verified",

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -237,7 +237,7 @@ class Runner
     end
   end
 
-  class Elixir < Runner
+  class Elixir < Runner # rubocop:disable Metrics/ClassLength
     def directory
       File.join(project_path, "elixir")
     end
@@ -273,7 +273,16 @@ class Runner
     end
 
     def before_setup
-      # Placeholder
+      # Delete previous versions of the AppSignal package so it doesn't get
+      # confused later on, in which package to stub the install and download
+      # reports
+      package_dirs = Dir.glob(
+        "_build/dev/rel/elixir_diagnose/lib/appsignal-*.*.*/",
+        :base => File.join(project_path, "elixir")
+      )
+      package_dirs.each do |dir|
+        FileUtils.rm_rf(dir)
+      end
     end
 
     def after_setup


### PR DESCRIPTION
## Fix Elixir install report stub

When we would release a new version of the Elixir package and then test
against it, it would create a directory in the build release directory
for that package version. Over time multiple versions could be in this
build release directory, causing the report stub behavior in
`after_setup` to be confused which package version to stub it in. It
would pick the first version, assuming there was only one directory.

I didn't want to do something like find the latest version of the
package, because that's not necessarily the one someone is currently
testing against.

Remove any AppSignal version package from the build release directory to
make sure it's always a clean state and it can't get confused about
which package version to write the report stubs to.

## Add extra fields for Elixir install report

To standardize the install reports a bit more for all the integrations
the Elixir integration will include the dependencies and flags fields as
well, so the stub should too.

## Update install report specs for Elixir

The install report for Elixir contains some fields other integrations do
not. Some of these should be added to the other integrations as well,
but because the Elixir integration has a download and install report
some fields will be duplicated. These duplicate fields are not necessary
for the other integrations.

## Remove private config option from Elixir output

The diagnose_endpoint is only used for testing, no need to print it in
the output.

## Implement missing assertions for Elixir

Implement the missing assertions for the Elixir integration. There are
some exceptions for this compared to the other integrations and we
should iron out the differences later.
