### PR TITLE
Test previously ignored lines

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -122,10 +122,10 @@ RSpec.describe "Running the diagnose command without any arguments" do
       "Extension installation report",
       /  Installation result/,
       /    Status: success/,
-      /  Language details/,
-      /    #{@runner.language_name} version: #{quoted VERSION_PATTERN}/
+      /  Language details/
     ]
-
+    matchers << /    Implementation: #{quoted "ruby"}/ if @runner.type == :ruby
+    matchers << /    #{@runner.language_name} version: #{quoted VERSION_PATTERN}/
     matchers << /    OTP version: #{quoted(/\d+/)}/ if @runner.type == :elixir
 
     matchers += [

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -162,8 +162,11 @@ RSpec.describe "Running the diagnose command without any arguments" do
       /    Musl override: #{TRUE_OR_FALSE_PATTERN}/,
       /    Linux ARM override: false/,
       /    Library type: #{quoted LIBRARY_TYPE_PATTERN}/,
+      /    Dependencies: %?\{\}/,
+      /    Flags: %?\{\}/,
       /  Host details/,
-      /    Root user: #{TRUE_OR_FALSE_PATTERN}/
+      /    Root user: #{TRUE_OR_FALSE_PATTERN}/,
+      /    Dependencies: %?\{\}/
     ]
     expect_output_for(:installation, matchers)
   end

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -178,7 +178,6 @@ class Runner
 
     def ignored_lines
       [
-        /Implementation: "ruby"/,
         /Flags: {}/,
         /Dependencies: {}/,
         /appsignal: Unable to log to /

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -178,8 +178,6 @@ class Runner
 
     def ignored_lines
       [
-        /Flags: {}/,
-        /Dependencies: {}/,
         /appsignal: Unable to log to /
       ]
     end
@@ -258,8 +256,7 @@ class Runner
       [
         /==> appsignal/,
         /AppSignal extension installation successful/,
-        /Download time:/,
-        /Dependencies: %{}/
+        /Download time:/
       ]
     end
 
@@ -377,8 +374,7 @@ class Runner
 
     def ignored_lines
       [
-        %r{WARNING: Error when reading appsignal config, appsignal \(as \d+/\d+\) not starting: Required environment variable '_APPSIGNAL_PUSH_API_KEY' not present}, # rubocop:disable Layout/LineLength
-        /Dependencies: {}/
+        %r{WARNING: Error when reading appsignal config, appsignal \(as \d+/\d+\) not starting: Required environment variable '_APPSIGNAL_PUSH_API_KEY' not present} # rubocop:disable Layout/LineLength
       ]
     end
 


### PR DESCRIPTION
Closes #14 

## Test the implementation output for Ruby

The line was ignored previously but we have a flexible enough system now
to test this extra line for the Ruby gem.

## Test dependencies and flags fields

Test if the dependencies and flags fields are printed in the diagnose
report. They were ignored before, but we can start testing them now.

