### PR TITLE
Test the report's "sources" sub-section

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
 cd "$(dirname "$0")/../"
 bundle config set --local gemfile ./Gemfile
 bundle install
-bundle exec rspec
+bundle exec rspec "$@"

--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -1,0 +1,3 @@
+Config.config :appsignal, :config,
+  name: "DiagnoseTests",
+  enable_minutely_probes: false

--- a/ruby/config/appsignal.yml
+++ b/ruby/config/appsignal.yml
@@ -1,0 +1,3 @@
+test:
+  name: "DiagnoseTests"
+  enable_minutely_probes: false

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -390,134 +390,138 @@ RSpec.describe "Running the diagnose command without any arguments" do
     expect_output_for(:config, matchers)
   end
 
-  it "submitted report contains configuration section" do
+  it "submitted report contains configuration options section" do
     expected_report_section =
       case @runner.type
       when :ruby
         {
-          "options" => {
-            "active" => true,
-            "ca_file_path" => matching(%r{.+/appsignal[-/]ruby/resources/cacert\.pem$}),
-            "debug" => false,
-            "dns_servers" => [],
-            "enable_allocation_tracking" => true,
-            "enable_gc_instrumentation" => false,
-            "enable_host_metrics" => true,
-            "enable_minutely_probes" => true,
-            "enable_statsd" => true,
-            "endpoint" => "https://push.appsignal.com",
-            "env" => "test",
-            "files_world_accessible" => true,
-            "filter_parameters" => [],
-            "filter_session_data" => [],
-            "ignore_actions" => [],
-            "ignore_errors" => [],
-            "ignore_namespaces" => [],
-            "instrument_net_http" => true,
-            "instrument_redis" => true,
-            "instrument_sequel" => true,
-            "log" => "file",
-            "push_api_key" => "test",
-            "request_headers" => [
-              "HTTP_ACCEPT",
-              "HTTP_ACCEPT_CHARSET",
-              "HTTP_ACCEPT_ENCODING",
-              "HTTP_ACCEPT_LANGUAGE",
-              "HTTP_CACHE_CONTROL",
-              "HTTP_CONNECTION",
-              "CONTENT_LENGTH",
-              "PATH_INFO",
-              "HTTP_RANGE",
-              "REQUEST_METHOD",
-              "REQUEST_URI",
-              "SERVER_NAME",
-              "SERVER_PORT",
-              "SERVER_PROTOCOL"
-            ],
-            "send_environment_metadata" => true,
-            "send_params" => true,
-            "skip_session_data" => false,
-            "transaction_debug_mode" => false
-          },
-          "sources" => kind_of(Hash) # TODO: make separate spec for this
+          "active" => true,
+          "ca_file_path" => matching(%r{.+/appsignal[-/]ruby/resources/cacert\.pem$}),
+          "debug" => false,
+          "dns_servers" => [],
+          "enable_allocation_tracking" => true,
+          "enable_gc_instrumentation" => false,
+          "enable_host_metrics" => true,
+          "enable_minutely_probes" => true,
+          "enable_statsd" => true,
+          "endpoint" => "https://push.appsignal.com",
+          "env" => "test",
+          "files_world_accessible" => true,
+          "filter_parameters" => [],
+          "filter_session_data" => [],
+          "ignore_actions" => [],
+          "ignore_errors" => [],
+          "ignore_namespaces" => [],
+          "instrument_net_http" => true,
+          "instrument_redis" => true,
+          "instrument_sequel" => true,
+          "log" => "file",
+          "push_api_key" => "test",
+          "request_headers" => [
+            "HTTP_ACCEPT",
+            "HTTP_ACCEPT_CHARSET",
+            "HTTP_ACCEPT_ENCODING",
+            "HTTP_ACCEPT_LANGUAGE",
+            "HTTP_CACHE_CONTROL",
+            "HTTP_CONNECTION",
+            "CONTENT_LENGTH",
+            "PATH_INFO",
+            "HTTP_RANGE",
+            "REQUEST_METHOD",
+            "REQUEST_URI",
+            "SERVER_NAME",
+            "SERVER_PORT",
+            "SERVER_PROTOCOL"
+          ],
+          "send_environment_metadata" => true,
+          "send_params" => true,
+          "skip_session_data" => false,
+          "transaction_debug_mode" => false
         }
       when :elixir
         {
-          "options" => {
-            "active" => true,
-            "ca_file_path" => ending_with("priv/cacert.pem"),
-            "debug" => false,
-            "diagnose_endpoint" => ENV["APPSIGNAL_DIAGNOSE_ENDPOINT"],
-            "dns_servers" => [],
-            "enable_host_metrics" => true,
-            "enable_minutely_probes" => true,
-            "enable_statsd" => false,
-            "endpoint" => "https://push.appsignal.com",
-            "env" => "dev",
-            "files_world_accessible" => true,
-            "filter_data_keys" => [],
-            "filter_parameters" => [],
-            "filter_session_data" => [],
-            "ignore_actions" => [],
-            "ignore_errors" => [],
-            "ignore_namespaces" => [],
-            "log" => "file",
-            "push_api_key" => "test",
-            "request_headers" => [
-              "accept",
-              "accept-charset",
-              "accept-encoding",
-              "accept-language",
-              "cache-control",
-              "connection",
-              "content-length",
-              "path-info",
-              "range",
-              "request-method",
-              "request-uri",
-              "server-name",
-              "server-port",
-              "server-protocol"
-            ],
-            "send_params" => true,
-            "skip_session_data" => false,
-            "transaction_debug_mode" => false,
-            "valid" => true
-          },
-          "sources" => kind_of(Hash) # TODO: make separate spec for this
+          "active" => true,
+          "ca_file_path" => ending_with("priv/cacert.pem"),
+          "debug" => false,
+          "diagnose_endpoint" => ENV["APPSIGNAL_DIAGNOSE_ENDPOINT"],
+          "dns_servers" => [],
+          "enable_host_metrics" => true,
+          "enable_minutely_probes" => true,
+          "enable_statsd" => false,
+          "endpoint" => "https://push.appsignal.com",
+          "env" => "dev",
+          "files_world_accessible" => true,
+          "filter_data_keys" => [],
+          "filter_parameters" => [],
+          "filter_session_data" => [],
+          "ignore_actions" => [],
+          "ignore_errors" => [],
+          "ignore_namespaces" => [],
+          "log" => "file",
+          "push_api_key" => "test",
+          "request_headers" => [
+            "accept",
+            "accept-charset",
+            "accept-encoding",
+            "accept-language",
+            "cache-control",
+            "connection",
+            "content-length",
+            "path-info",
+            "range",
+            "request-method",
+            "request-uri",
+            "server-name",
+            "server-port",
+            "server-protocol"
+          ],
+          "send_params" => true,
+          "skip_session_data" => false,
+          "transaction_debug_mode" => false,
+          "valid" => true
         }
       when :nodejs
         {
-          "options" => {
-            "active" => true,
-            "ca_file_path" => ending_with("cert/cacert.pem"),
-            "debug" => false,
-            "dns_servers" => [],
-            "enable_host_metrics" => true,
-            "enable_minutely_probes" => true,
-            "enable_statsd" => false,
-            "endpoint" => "https://push.appsignal.com",
-            "env" => "test",
-            "files_world_accessible" => true,
-            "filter_data_keys" => [],
-            "filter_parameters" => [],
-            "filter_session_data" => [],
-            "ignore_actions" => [],
-            "ignore_errors" => [],
-            "ignore_namespaces" => [],
-            "log" => "file",
-            "log_file_path" => "/tmp/appsignal.log",
-            "log_path" => "/tmp",
-            "push_api_key" => "test",
-            "transaction_debug_mode" => false
-          },
-          "sources" => {} # TODO: Fix in integration: https://github.com/appsignal/appsignal-nodejs/issues/473
+          "active" => true,
+          "ca_file_path" => ending_with("cert/cacert.pem"),
+          "debug" => false,
+          "dns_servers" => [],
+          "enable_host_metrics" => true,
+          "enable_minutely_probes" => true,
+          "enable_statsd" => false,
+          "endpoint" => "https://push.appsignal.com",
+          "env" => "test",
+          "files_world_accessible" => true,
+          "filter_data_keys" => [],
+          "filter_parameters" => [],
+          "filter_session_data" => [],
+          "ignore_actions" => [],
+          "ignore_errors" => [],
+          "ignore_namespaces" => [],
+          "log" => "file",
+          "log_file_path" => "/tmp/appsignal.log",
+          "log_path" => "/tmp",
+          "push_api_key" => "test",
+          "transaction_debug_mode" => false
         }
       else
         raise "No clause for runner #{@runner}"
       end
 
-    expect_report_for(:config, expected_report_section)
+    expect_report_for(:config, :options, expected_report_section)
+  end
+
+  it "submitted report contains configuration sources section" do
+    expected_report_section =
+      case @runner.type
+      when :ruby, :elixir
+        kind_of(Hash)
+      when :nodejs
+        {}
+      else
+        raise "No clause for runner #{@runner}"
+      end
+    expect_report_for(:config, :sources, expected_report_section)
   end
 
   it "prints the validation section" do

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -514,8 +514,110 @@ RSpec.describe "Running the diagnose command without any arguments" do
   it "submitted report contains configuration sources section" do
     expected_report_section =
       case @runner.type
-      when :ruby, :elixir
-        kind_of(Hash)
+      when :ruby
+        {
+          "default" => {
+            "ca_file_path" => matching(%r{.+/appsignal[-/]ruby/resources/cacert\.pem$}),
+            "debug" => false,
+            "dns_servers" => [],
+            "enable_allocation_tracking" => true,
+            "enable_gc_instrumentation" => false,
+            "enable_host_metrics" => true,
+            "enable_minutely_probes" => true,
+            "enable_statsd" => true,
+            "endpoint" => "https://push.appsignal.com",
+            "files_world_accessible" => true,
+            "filter_parameters" => [],
+            "filter_session_data" => [],
+            "ignore_actions" => [],
+            "ignore_errors" => [],
+            "ignore_namespaces" => [],
+            "instrument_net_http" => true,
+            "instrument_redis" => true,
+            "instrument_sequel" => true,
+            "log" => "file",
+            "request_headers" => [
+              "HTTP_ACCEPT",
+              "HTTP_ACCEPT_CHARSET",
+              "HTTP_ACCEPT_ENCODING",
+              "HTTP_ACCEPT_LANGUAGE",
+              "HTTP_CACHE_CONTROL",
+              "HTTP_CONNECTION",
+              "CONTENT_LENGTH",
+              "PATH_INFO",
+              "HTTP_RANGE",
+              "REQUEST_METHOD",
+              "REQUEST_URI",
+              "SERVER_NAME",
+              "SERVER_PORT",
+              "SERVER_PROTOCOL"
+            ],
+            "send_environment_metadata" => true,
+            "send_params" => true,
+            "skip_session_data" => false,
+            "transaction_debug_mode" => false
+          },
+          "env" => {
+            "push_api_key" => "test"
+          },
+          "file" => {},
+          "initial" => {
+            "env" => "test"
+          },
+          "system" => {
+            "active" => true
+          }
+        }
+      when :elixir
+        {
+          "default" => {
+            "active" => false,
+            "ca_file_path" => ending_with("priv/cacert.pem"),
+            "debug" => false,
+            "diagnose_endpoint" => "https://appsignal.com/diag",
+            "dns_servers" => [],
+            "enable_host_metrics" => true,
+            "enable_minutely_probes" => true,
+            "enable_statsd" => false,
+            "endpoint" => "https://push.appsignal.com",
+            "env" => "dev",
+            "files_world_accessible" => true,
+            "filter_data_keys" => [],
+            "filter_parameters" => [],
+            "filter_session_data" => [],
+            "ignore_actions" => [],
+            "ignore_errors" => [],
+            "ignore_namespaces" => [],
+            "log" => "file",
+            "request_headers" => [
+              "accept",
+              "accept-charset",
+              "accept-encoding",
+              "accept-language",
+              "cache-control",
+              "connection",
+              "content-length",
+              "path-info",
+              "range",
+              "request-method",
+              "request-uri",
+              "server-name",
+              "server-port",
+              "server-protocol"
+            ],
+            "send_params" => true,
+            "skip_session_data" => false,
+            "transaction_debug_mode" => false
+          },
+          "env" => {
+            "diagnose_endpoint" => "http://localhost:4005/diag",
+            "push_api_key" => "test"
+          },
+          "file" => {},
+          "system" => {
+            "active" => true
+          }
+        }
       when :nodejs
         {}
       else

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
     case @runner.type
     when :ruby
       matchers += [
-        /  Environment: #{quoted("test")}/,
+        /  Environment: #{quoted("test")} \(Loaded from: initial\)/,
         /  debug: false/,
         /  log: #{quoted("file")}/,
         /  ignore_actions: \[\]/,
@@ -316,13 +316,17 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  enable_allocation_tracking: true/,
         /  enable_gc_instrumentation: false/,
         /  enable_host_metrics: true/,
-        /  enable_minutely_probes: true/,
+        /  enable_minutely_probes: false/,
+        /    Sources:/,
+        /      default: true/,
+        /      file:    false/,
         /  enable_statsd: true/,
         %r{  ca_file_path: ".+/appsignal[-/]ruby/resources/cacert.pem"},
         /  dns_servers: \[\]/,
         /  files_world_accessible: true/,
         /  transaction_debug_mode: false/,
         /  active: true \(Loaded from: system\)/,
+        /  name: #{quoted "DiagnoseTests"} \(Loaded from: file\)/,
         /  push_api_key: "test" \(Loaded from: env\)/
       ]
     when :nodejs
@@ -359,7 +363,10 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  debug: false/,
         /  dns_servers: \[\]/,
         /  enable_host_metrics: true/,
-        /  enable_minutely_probes: true/,
+        /  enable_minutely_probes: false/,
+        /    Sources:/,
+        /      default: true/,
+        /      file:    false/,
         /  enable_statsd: false/,
         /  endpoint: #{quoted "https://push.appsignal.com"}/,
         /  env: "dev"/,
@@ -371,6 +378,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  ignore_errors: \[\]/,
         /  ignore_namespaces: \[\]/,
         /  log: "file"/,
+        /  name: #{quoted "DiagnoseTests"} \(Loaded from file\)/,
         /  push_api_key: #{quoted "test"} \(Loaded from env\)/,
         /  request_headers: \["accept", "accept-charset", "accept-encoding", "accept-language", "cache-control", "connection", "content-length", "path-info", "range", "request-method", "request-uri", "server-name", "server-port", "server-protocol"\]/, # rubocop:disable Layout/LineLength
         /  send_params: true/,
@@ -402,7 +410,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "enable_allocation_tracking" => true,
           "enable_gc_instrumentation" => false,
           "enable_host_metrics" => true,
-          "enable_minutely_probes" => true,
+          "enable_minutely_probes" => false,
           "enable_statsd" => true,
           "endpoint" => "https://push.appsignal.com",
           "env" => "test",
@@ -416,6 +424,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "instrument_redis" => true,
           "instrument_sequel" => true,
           "log" => "file",
+          "name" => "DiagnoseTests",
           "push_api_key" => "test",
           "request_headers" => [
             "HTTP_ACCEPT",
@@ -446,7 +455,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "diagnose_endpoint" => ENV["APPSIGNAL_DIAGNOSE_ENDPOINT"],
           "dns_servers" => [],
           "enable_host_metrics" => true,
-          "enable_minutely_probes" => true,
+          "enable_minutely_probes" => false,
           "enable_statsd" => false,
           "endpoint" => "https://push.appsignal.com",
           "env" => "dev",
@@ -458,6 +467,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "ignore_errors" => [],
           "ignore_namespaces" => [],
           "log" => "file",
+          "name" => "DiagnoseTests",
           "push_api_key" => "test",
           "request_headers" => [
             "accept",
@@ -560,7 +570,10 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "env" => {
             "push_api_key" => "test"
           },
-          "file" => {},
+          "file" => {
+            "enable_minutely_probes" => false,
+            "name" => "DiagnoseTests"
+          },
           "initial" => {
             "env" => "test"
           },
@@ -613,7 +626,10 @@ RSpec.describe "Running the diagnose command without any arguments" do
             "diagnose_endpoint" => "http://localhost:4005/diag",
             "push_api_key" => "test"
           },
-          "file" => {},
+          "file" => {
+            "name" => "DiagnoseTests",
+            "enable_minutely_probes" => false
+          },
           "system" => {
             "active" => true
           }

--- a/spec/support/diagnose_report_helper.rb
+++ b/spec/support/diagnose_report_helper.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module DiagnoseReportHelper
-  def expect_report_for(section_key, expected)
+  def expect_report_for(*section_keys, expected)
     unless @received_report
       raise "expect_report_for: No @received_report found, is `#{@received_report.inspect}`"
     end
 
-    section = @received_report.section(section_key.to_s)
+    section = @received_report.section(*section_keys)
     expect(section).to match(expected)
   end
 

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -10,8 +10,10 @@ class DiagnoseReport
     @report = report
   end
 
-  def section(key)
-    @report.fetch(key.to_s) { raise "No `#{key}` key found in the DiagnoseReport" }
+  def section(*keys)
+    @report.dig(*keys.map(&:to_s)).tap do |section|
+      raise "No `#{keys}` keys found in the DiagnoseReport" if section.nil?
+    end
   end
 
   def to_h


### PR DESCRIPTION
This PR is part of https://github.com/appsignal/appsignal-nodejs/issues/473.

### Pass extra `bin/test` arguments to rspec

This commit modifies the `bin/test` script so that extra arguments given to it are passed through to the `bundle exec rspec` invocation.

### Test each config sub-section independently

To separate the test for the `options` section of the config from the one for the `sources` section of the config, the `section` method in the `DiagnoseReport` is modified so that it takes a series of keys to pass to `Hash#dig` on the report, instead of a key to pass to `Hash#fetch`.

The implementation-pending assertions on the sources are moved to a separate test.

### Add actual checks for sources sub-section

This commit implements the checks for the `sources` sub-section of the report for Ruby and Elixir. The Node.js implementation is still pending.

### Add config sourced from file

In order to test the behaviour when configuration variables are set in the configuration files for each platform, configuration files are added to the `ruby` and `elixir` project folders.

The `enable_minutely_probes` key is modified within these files as well, in order to ensure overrides from the defaults are tested.