### PR TITLE
Expect params' `name` to be non-empty

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -24,13 +24,23 @@ RSpec.describe "Running the diagnose command without any arguments" do
     matchers =
       case @runner.type
       when :ruby
-        { "gem_version" => VERSION_PATTERN }
+        {
+          "gem_version" => VERSION_PATTERN,
+          "name" => "DiagnoseTests"
+        }
+      when :elixir
+        {
+          "name" => "DiagnoseTests"
+        }
+      when :nodejs
+        {
+          "name" => be_empty.or(be_nil)
+        }
       end
 
     expect(@received_report.params).to match(
       {
         "api_key" => "test",
-        "name" => be_empty.or(be_nil),
         "environment" => kind_of(String),
         "hostname" => be_empty.or(be_nil)
       }.merge(matchers || {})
@@ -984,13 +994,23 @@ RSpec.describe "Running the diagnose command without Push API key" do
     matchers =
       case @runner.type
       when :ruby
-        { "gem_version" => VERSION_PATTERN }
+        {
+          "gem_version" => VERSION_PATTERN,
+          "name" => "DiagnoseTests"
+        }
+      when :elixir
+        {
+          "name" => "DiagnoseTests"
+        }
+      when :nodejs
+        {
+          "name" => be_empty.or(be_nil)
+        }
       end
 
     expect(@received_report.params).to match(
       {
         "api_key" => be_empty.or(be_nil),
-        "name" => be_empty.or(be_nil),
         "environment" => kind_of(String),
         "hostname" => be_empty.or(be_nil)
       }.merge(matchers || {})


### PR DESCRIPTION
In PR #30, a test that checks that the name is sent as empty in the diagnose request params was added, while in PR #34, a config file that makes the name not empty was added for the Ruby and Elixir test projects.

This commit aligns the expectations in #30 with the changes in #34 by expecting the name to be set in Ruby and Elixir.