### PR TITLE
Add Node.js sources to the diagnose report

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -662,7 +662,35 @@ RSpec.describe "Running the diagnose command without any arguments" do
           }
         }
       when :nodejs
-        {}
+        {
+          "default" => {
+            "ca_file_path" => ending_with("cert/cacert.pem"),
+            "debug" => false,
+            "dns_servers" => [],
+            "enable_host_metrics" => true,
+            "enable_minutely_probes" => true,
+            "enable_statsd" => false,
+            "endpoint" => "https://push.appsignal.com",
+            "env" => "development",
+            "files_world_accessible" => true,
+            "filter_data_keys" => [],
+            "filter_parameters" => [],
+            "filter_session_data" => [],
+            "ignore_actions" => [],
+            "ignore_errors" => [],
+            "ignore_namespaces" => [],
+            "log" => "file",
+            "log_path" => "/tmp",
+            "transaction_debug_mode" => false
+          },
+          "env" => {
+            "env" => "test",
+            "push_api_key" => "test"
+          },
+          "initial" => {
+            "active" => true
+          }
+        }
       else
         raise "No clause for runner #{@runner}"
       end

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
       ]
     when :nodejs
       matchers += [
-        /  active: true/,
+        /  active: true \(Loaded from: initial\)/,
         /  ca_file_path: #{quoted ".+\/cacert.pem"}/,
         /  debug: false/,
         /  dns_servers: \[\]/,
@@ -367,6 +367,9 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  enable_statsd: false/,
         /  endpoint: #{quoted "https://push.appsignal.com"}/,
         /  env: #{quoted("test")}/,
+        /    Sources:/,
+        /      default: #{quoted("development")}/,
+        /      env:     #{quoted("test")}/,
         /  files_world_accessible: true/,
         /  filter_data_keys: \[\]/,
         /  filter_parameters: \[\]/,
@@ -377,7 +380,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  log: #{quoted("file")}/,
         /  log_file_path: #{quoted ".+\/appsignal.log"}/,
         /  log_path: #{quoted("/tmp")}/,
-        /  push_api_key: #{quoted "test"}/,
+        /  push_api_key: #{quoted "test"} \(Loaded from: env\)/,
         /  transaction_debug_mode: false/
       ]
     when :elixir


### PR DESCRIPTION
See appsignal/appsignal-nodejs#484 for the implementation.

### Add sources checks for Node.js

This commit adds checks for the sources section of the diagnose report for the Node.js integration.

### Expect sources in Node.js config output

This commit adds expectations for the Node.js report output to contain information about which sources provide which configuration values.