### PR TITLE
Test Push API key validation

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -726,6 +726,25 @@ RSpec.describe "Running the diagnose command without any arguments" do
     )
   end
 
+  it "validates the Push API key with the correct query params" do
+    matchers =
+      case @runner.type
+      when :ruby
+        {
+          "gem_version" => VERSION_PATTERN
+        }
+      end
+
+    expect(MockServer.last_auth_request.params).to match(
+      {
+        "api_key" => "test",
+        "environment" => kind_of(String),
+        "hostname" => be_empty.or(be_nil),
+        "name" => "DiagnoseTests"
+      }.merge(matchers || {})
+    )
+  end
+
   it "prints the paths section" do
     matchers = ["Paths"]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,19 +43,20 @@ RSpec.configure do |config|
   config.before :suite do
     # Configure integrations to submit their report to a custom server
     port = 4005
+    ENV["APPSIGNAL_PUSH_API_ENDPOINT"] = "http://localhost:#{port}"
     ENV["APPSIGNAL_DIAGNOSE_ENDPOINT"] = "http://localhost:#{port}/diag"
-    # Boot mock diagnose report server
-    Thread.new { DiagnoseServer.run!(port) }
+    # Boot mock AppSignal server
+    Thread.new { MockServer.run!(port) }
     # Wait for Sinatra to boot if needed
-    sleep 0.01 until DiagnoseServer.running?
+    sleep 0.01 until MockServer.running?
   end
 
   config.after :context do
-    DiagnoseServer.clear!
+    MockServer.clear!
   end
 
   config.after :suite do
-    DiagnoseServer.clear!
-    DiagnoseServer.quit!
+    MockServer.clear!
+    MockServer.quit!
   end
 end

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -21,23 +21,24 @@ class DiagnoseReport
   end
 end
 
-class DiagnoseServer < Sinatra::Base
+class MockServer < Sinatra::Base
   class << self
     def run!(port)
       @mutex = Mutex.new
-      @received_requests = []
+      @auth_response_code = 200
+      @received_diagnose_requests = []
       super(:port => port)
     end
 
-    def track_request(request)
+    def track_diagnose_request(request)
       @mutex.synchronize do
-        @received_requests << request
+        @received_diagnose_requests << request
       end
     end
 
-    def last_received_report
+    def last_diagnose_report
       @mutex.synchronize do
-        request = @received_requests.last
+        request = @received_diagnose_requests.last
         if request
           DiagnoseReport.new(
             :params => request.params,
@@ -47,9 +48,22 @@ class DiagnoseServer < Sinatra::Base
       end
     end
 
+    def auth_response_code
+      @mutex.synchronize do
+        @auth_response_code
+      end
+    end
+
+    def auth_response_code=(code)
+      @mutex.synchronize do
+        @auth_response_code = code
+      end
+    end
+
     def clear!
       @mutex.synchronize do
-        @received_requests.clear
+        @auth_response_code = 200
+        @received_diagnose_requests.clear
       end
     end
   end
@@ -57,8 +71,12 @@ class DiagnoseServer < Sinatra::Base
   set :logging, false
 
   post "/diag" do
-    DiagnoseServer.track_request(request)
+    MockServer.track_diagnose_request(request)
     status 200
     JSON.dump({ :token => "diag_support_token" })
+  end
+
+  post "/1/auth" do
+    status MockServer.auth_response_code
   end
 end

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -26,6 +26,7 @@ class MockServer < Sinatra::Base
     def run!(port)
       @mutex = Mutex.new
       @auth_response_code = 200
+      @received_auth_requests = []
       @received_diagnose_requests = []
       super(:port => port)
     end
@@ -48,6 +49,18 @@ class MockServer < Sinatra::Base
       end
     end
 
+    def track_auth_request(request)
+      @mutex.synchronize do
+        @received_auth_requests << request
+      end
+    end
+
+    def last_auth_request
+      @mutex.synchronize do
+        @received_auth_requests.last
+      end
+    end
+
     def auth_response_code
       @mutex.synchronize do
         @auth_response_code
@@ -63,6 +76,7 @@ class MockServer < Sinatra::Base
     def clear!
       @mutex.synchronize do
         @auth_response_code = 200
+        @received_auth_requests.clear
         @received_diagnose_requests.clear
       end
     end
@@ -77,6 +91,7 @@ class MockServer < Sinatra::Base
   end
 
   post "/1/auth" do
+    MockServer.track_auth_request(request)
     status MockServer.auth_response_code
   end
 end


### PR DESCRIPTION
Add an extra endpoint to the MockServer to test the Push API key
validation.

I renamed the DiagnoseServer to MockServer to allow it to be used for
more tests.