### PR TITLE
Fix Node.js sources environment and remove `log_path_file`

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -25,16 +25,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
       case @runner.type
       when :ruby
         {
-          "gem_version" => VERSION_PATTERN,
-          "name" => "DiagnoseTests"
-        }
-      when :elixir
-        {
-          "name" => "DiagnoseTests"
-        }
-      when :nodejs
-        {
-          "name" => be_empty.or(be_nil)
+          "gem_version" => VERSION_PATTERN
         }
       end
 
@@ -42,7 +33,8 @@ RSpec.describe "Running the diagnose command without any arguments" do
       {
         "api_key" => "test",
         "environment" => kind_of(String),
-        "hostname" => be_empty.or(be_nil)
+        "hostname" => be_empty.or(be_nil),
+        "name" => "DiagnoseTests"
       }.merge(matchers || {})
     )
   end
@@ -382,6 +374,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  ignore_namespaces: \[\]/,
         /  log: #{quoted("file")}/,
         /  log_path: #{quoted("/tmp")}/,
+        /  name: #{quoted "DiagnoseTests"} \(Loaded from: env\)/,
         /  push_api_key: #{quoted "test"} \(Loaded from: env\)/,
         /  transaction_debug_mode: false/
       ]
@@ -542,6 +535,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "ignore_namespaces" => [],
           "log" => "file",
           "log_path" => "/tmp",
+          "name" => "DiagnoseTests",
           "push_api_key" => "test",
           "transaction_debug_mode" => false
         }
@@ -689,7 +683,8 @@ RSpec.describe "Running the diagnose command without any arguments" do
           },
           "env" => {
             "enable_minutely_probes" => false,
-            "push_api_key" => "test"
+            "push_api_key" => "test",
+            "name" => "DiagnoseTests"
           },
           "initial" => {
             "active" => true
@@ -1027,16 +1022,7 @@ RSpec.describe "Running the diagnose command without Push API key" do
       case @runner.type
       when :ruby
         {
-          "gem_version" => VERSION_PATTERN,
-          "name" => "DiagnoseTests"
-        }
-      when :elixir
-        {
-          "name" => "DiagnoseTests"
-        }
-      when :nodejs
-        {
-          "name" => be_empty.or(be_nil)
+          "gem_version" => VERSION_PATTERN
         }
       end
 
@@ -1044,7 +1030,8 @@ RSpec.describe "Running the diagnose command without Push API key" do
       {
         "api_key" => be_empty.or(be_nil),
         "environment" => kind_of(String),
-        "hostname" => be_empty.or(be_nil)
+        "hostname" => be_empty.or(be_nil),
+        "name" => "DiagnoseTests"
       }.merge(matchers || {})
     )
   end

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
     case @runner.type
     when :ruby
       matchers += [
-        /  Environment: #{quoted("test")} \(Loaded from: initial\)/,
+        /  Environment: #{quoted("development")} \(Loaded from: initial\)/,
         /  debug: false/,
         /  log: #{quoted("file")}/,
         /  ignore_actions: \[\]/,
@@ -366,13 +366,13 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  debug: false/,
         /  dns_servers: \[\]/,
         /  enable_host_metrics: true/,
-        /  enable_minutely_probes: true/,
+        /  enable_minutely_probes: false/,
+        /    Sources:/,
+        /      default: true/,
+        /      env:     false/,
         /  enable_statsd: false/,
         /  endpoint: #{quoted "https://push.appsignal.com"}/,
-        /  env: #{quoted("test")}/,
-        /    Sources:/,
-        /      default: #{quoted("development")}/,
-        /      env:     #{quoted("test")}/,
+        /  env: #{quoted("development")}/,
         /  files_world_accessible: true/,
         /  filter_data_keys: \[\]/,
         /  filter_parameters: \[\]/,
@@ -446,7 +446,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "enable_minutely_probes" => false,
           "enable_statsd" => true,
           "endpoint" => "https://push.appsignal.com",
-          "env" => "test",
+          "env" => "development",
           "files_world_accessible" => true,
           "filter_parameters" => [],
           "filter_session_data" => [],
@@ -530,10 +530,10 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "debug" => false,
           "dns_servers" => [],
           "enable_host_metrics" => true,
-          "enable_minutely_probes" => true,
+          "enable_minutely_probes" => false,
           "enable_statsd" => false,
           "endpoint" => "https://push.appsignal.com",
-          "env" => "test",
+          "env" => "development",
           "files_world_accessible" => true,
           "filter_data_keys" => [],
           "filter_parameters" => [],
@@ -608,7 +608,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
             "name" => "DiagnoseTests"
           },
           "initial" => {
-            "env" => "test"
+            "env" => "development"
           },
           "system" => {
             "active" => true
@@ -690,7 +690,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
             "transaction_debug_mode" => false
           },
           "env" => {
-            "env" => "test",
+            "enable_minutely_probes" => false,
             "push_api_key" => "test"
           },
           "initial" => {

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -381,7 +381,6 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  ignore_errors: \[\]/,
         /  ignore_namespaces: \[\]/,
         /  log: #{quoted("file")}/,
-        /  log_file_path: #{quoted ".+\/appsignal.log"}/,
         /  log_path: #{quoted("/tmp")}/,
         /  push_api_key: #{quoted "test"} \(Loaded from: env\)/,
         /  transaction_debug_mode: false/
@@ -542,7 +541,6 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "ignore_errors" => [],
           "ignore_namespaces" => [],
           "log" => "file",
-          "log_file_path" => "/tmp/appsignal.log",
           "log_path" => "/tmp",
           "push_api_key" => "test",
           "transaction_debug_mode" => false

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -385,7 +385,8 @@ class Runner
     def run_env
       super.merge({
         "NODE_ENV" => "development",
-        "APPSIGNAL_ENABLE_MINUTELY_PROBES" => "false"
+        "APPSIGNAL_ENABLE_MINUTELY_PROBES" => "false",
+        "APPSIGNAL_APP_NAME" => "DiagnoseTests"
       })
     end
 


### PR DESCRIPTION
### Ensure env is always development

This commit ensures that the `environment` configuration value is always set to `development` for all integrations. For the Node integration, it sets `NODE_ENV` instead of setting `APPSIGNAL_APP_ENV`.

To do so, the way environment variables are handled in the `Runner` and its subclasses is modified, with a new `run_env` function that subclasses can implement. `run_command` is also modified so that it takes the command-line arguments as an argument.

In order to continue testing the behaviour for the Node diagnose output when multiple configuration sources have values for the same configuration key, and in concordance with the behaviour of the other integrations, the `enable_minutely_probes` key is set to `false`, overriding its default value.

### Remove log_file_path from expected output

This commit removes `log_file_path` from the expected output for the config section of the Node.js integration.

### Ensure name is always DiagnoseTests 

To unify the behaviour across all integrations, the Node.js integration now receives an environment variable setting the application name to "DiagnoseTests".