### PR TITLE
Set config for development env

### DIFF
--- a/ruby/config/appsignal.yml
+++ b/ruby/config/appsignal.yml
@@ -1,3 +1,3 @@
-test:
+development:
   name: "DiagnoseTests"
   enable_minutely_probes: false


### PR DESCRIPTION
In #38, the default environment for the diagnose test projects was changed to be `development` instead of `test`, but the config file for the Ruby project was not changed accordingly; this commit fixes that.