### PR TITLE
Add scenario for report submission failure

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../../..
   specs:
-    appsignal (3.0.14)
+    appsignal (3.0.15)
       rack
 
 GEM
@@ -16,4 +16,4 @@ DEPENDENCIES
   appsignal!
 
 BUNDLED WITH
-   2.2.17
+   2.2.28


### PR DESCRIPTION
There's a new scenario that tests when the diagnose report fails to get
submitted to AppSignal.

Now, when mocking the diagnose request, we must add the expected
response code explicitly.

Closes #32 