### PR TITLE
The Node.js apiKey option is renamed to pushApiKey

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -359,7 +359,6 @@ RSpec.describe "Running the diagnose command without any arguments" do
     when :nodejs
       matchers += [
         /  active: true \(Loaded from: initial\)/,
-        /  apiKey: #{quoted "test"} \(Loaded from: env\)/,
         /  caFilePath: #{quoted ".+\/cacert.pem"}/,
         /  debug: false/,
         /  dnsServers: \[\]/,
@@ -383,6 +382,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  log: #{quoted("file")}/,
         /  logPath: #{quoted("/tmp")}/,
         /  name: #{quoted "DiagnoseTests"} \(Loaded from: env\)/,
+        /  pushApiKey: #{quoted "test"} \(Loaded from: env\)/,
         /  transactionDebugMode: false/
       ]
     when :elixir


### PR DESCRIPTION
Update the spec to match the new config option name.

[skip review] because it's a small rename that's addressed in more detail in https://github.com/appsignal/appsignal-nodejs/pull/507.