### PR TITLE
Add system source to Node.js config sources

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -694,7 +694,8 @@ RSpec.describe "Running the diagnose command without any arguments" do
           },
           "initial" => {
             "active" => true
-          }
+          },
+          "system" => {}
         }
       else
         raise "No clause for runner #{@runner}"


### PR DESCRIPTION
The Node.js integration now has a system source. It's empty by default
unlike the other integrations, because it doesn't listen to the
`APPSIGNAL_PUSH_API_KEY` yet to set the active config option to `true`.

It's only there for the `log` option to "stdout" on Heroku dynos.

[skip review] because it's only another source addition, similar to what other integrations already have. The real review is in https://github.com/appsignal/appsignal-nodejs/pull/509