### PR TITLE
Remove extension package from Node.js deps

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@appsignal/nodejs": "*",
-    "@appsignal/nodejs-ext": "*"
+    "@appsignal/nodejs": "*"
   }
 }

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -389,11 +389,9 @@ class Runner
     end
 
     def setup_commands
-      package_paths = ["nodejs", "nodejs-ext"].map do |package|
-        File.join(integration_path, "packages", package)
-      end
+      package_path = File.join(integration_path, "packages", "nodejs")
 
-      ["npm link #{package_paths.join(" ")}"]
+      ["npm link #{package_path}"]
     end
 
     def run_env


### PR DESCRIPTION
As the extension package is now merged inside the Node.js core package,
there's no need to install it anymore.