### PR TITLE
Expect active to be false on Node.js

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
       ]
     when :nodejs
       matchers += [
-        /  active: true \(Loaded from: initial\)/,
+        /  active: false/,
         /  caFilePath: #{quoted ".+\/cacert.pem"}/,
         /  debug: false/,
         /  dnsServers: \[\]/,
@@ -522,7 +522,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         }
       when :nodejs
         {
-          "active" => true,
+          "active" => false,
           "ca_file_path" => ending_with("cert/cacert.pem"),
           "debug" => false,
           "dns_servers" => [],
@@ -674,6 +674,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
       when :nodejs
         {
           "default" => {
+            "active" => false,
             "ca_file_path" => ending_with("cert/cacert.pem"),
             "debug" => false,
             "dns_servers" => [],
@@ -710,9 +711,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
             "push_api_key" => "test",
             "name" => "DiagnoseTests"
           },
-          "initial" => {
-            "active" => true
-          },
+          "initial" => {},
           "system" => {}
         }
       else


### PR DESCRIPTION
This matches the changes introduced in [appsignal-nodejs#548][pr], where the `active` config option is added to the default values, and the configuration object is not invoked with `active` set to `true` as an initial value in the diagnose.

[pr]: https://github.com/appsignal/appsignal-nodejs/pull/548