### PR TITLE
Add send_session_data to Elixir

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -420,6 +420,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  request_headers: \["accept", "accept-charset", "accept-encoding", "accept-language", "cache-control", "connection", "content-length", "range"\]/, # rubocop:disable Layout/LineLength
         /  send_environment_metadata: true/,
         /  send_params: true/,
+        /  send_session_data: true/,
         /  skip_session_data: false/,
         /  transaction_debug_mode: false/
       ]
@@ -517,6 +518,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
           ],
           "send_environment_metadata" => true,
           "send_params" => true,
+          "send_session_data" => true,
           "skip_session_data" => false,
           "transaction_debug_mode" => false
         }
@@ -655,7 +657,6 @@ RSpec.describe "Running the diagnose command without any arguments" do
             ],
             "send_environment_metadata" => true,
             "send_params" => true,
-            "skip_session_data" => false,
             "transaction_debug_mode" => false
           },
           "env" => {


### PR DESCRIPTION
The `send_session_data` is the new option to be used after the
deprecation of `skip_session_data`. This commit updates the Elixir tests
to match with the new option.