### PR TITLE
Add Elixir override config source

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -670,6 +670,10 @@ RSpec.describe "Running the diagnose command without any arguments" do
           },
           "system" => {
             "active" => true
+          },
+          "override" => {
+            "send_session_data" => true,
+            "skip_session_data" => false
           }
         }
       when :nodejs


### PR DESCRIPTION
Add override config source to Elixir specs for the `skip_session_data`
and `send_session_data` config options.

This allows to see better when certain config options are set in the
configuration process. This config source is leading.

Part of https://github.com/appsignal/appsignal-elixir/issues/752