### PR TITLE
Ruby move send_session_data to the override source

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -621,7 +621,9 @@ RSpec.describe "Running the diagnose command without any arguments" do
             "env" => "development"
           },
           "system" => {
-            "active" => true,
+            "active" => true
+          },
+          "override" => {
             "send_session_data" => true
           }
         }

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -2,7 +2,7 @@
 
 VERSION_PATTERN = /\d+\.\d+\.\d+(-[a-z0-9]+)?/
 REVISION_PATTERN = /[a-z0-9]{7}/
-ARCH_PATTERN = /(x(86_)?64|i686)/
+ARCH_PATTERN = /(x(86_)?64|i686|arm64)/
 TARGET_PATTERN = /(darwin\d*|linux(-gnu|-musl)?|freebsd)/
 LIBRARY_TYPE_PATTERN = /static|dynamic/
 TAR_FILENAME_PATTERN =


### PR DESCRIPTION
## Fix diagnose tests for local ARM host

I'm developing on an ARM machine and the test fail because it expects
x86 architecture. Add the ARM architecture as well so it will run
locally.

## Ruby move send_session_data to the override source

For the Ruby gem we now track `send_session_data` in the `override`
config source. The system source is too early in the config load order
and it was previously set much later, which meant it could result in an
inaccurate diagnose report.

Part of https://github.com/appsignal/appsignal-ruby/issues/811
