### PR TITLE
Fix Node.js version matcher

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION_PATTERN = /\d+\.\d+\.\d+(-[a-z0-9]+)?/
+VERSION_PATTERN = /\d+\.\d+\.\d+(-[a-z0-9]+)?([-.].+)?/
 REVISION_PATTERN = /[a-z0-9]{7}/
 ARCH_PATTERN = /(x(86_)?64|i686|arm64)/
 TARGET_PATTERN = /(darwin\d*|linux(-gnu|-musl)?|freebsd)/


### PR DESCRIPTION
We've released a beta version and the diagnose tests failed on that because it didn't expect the prerelease suffix. I've updated the version matcher to account for that.

[skip review]