### PR TITLE
Track OS distro in diagnose report

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -247,6 +247,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
       "heroku" => false,
       "language_version" => VERSION_PATTERN,
       "os" => TARGET_PATTERN,
+      "os_distribution" => kind_of(String),
       "root" => false,
       "running_in_container" => boolean
     }


### PR DESCRIPTION
This helps us with debugging what exact version of Linux an app is running on, for example.

[skip review]
Required for https://github.com/appsignal/appsignal-ruby/pull/901