### PR TITLE
Test config opts coming from the Node.js client

### DIFF
--- a/nodejs/appsignal.cjs
+++ b/nodejs/appsignal.cjs
@@ -1,1 +1,7 @@
-{}
+const { Appsignal } = require("@appsignal/nodejs");
+
+new Appsignal({
+  active: true,
+  name: "DiagnoseTests",
+  logLevel: "debug",
+});

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -363,7 +363,10 @@ RSpec.describe "Running the diagnose command without any arguments" do
       ]
     when :nodejs
       matchers += [
-        /  active: false/,
+        /  active: true/,
+        /    Sources:/,
+        /      default: false/,
+        /      initial: true/,
         /  caFilePath: #{quoted ".+\/cacert.pem"}/,
         /  disableDefaultInstrumentations: false/,
         /  dnsServers: \[\]/,
@@ -386,8 +389,12 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  ignoreErrors: \[\]/,
         /  ignoreNamespaces: \[\]/,
         /  log: #{quoted("file")}/,
+        /  logLevel: #{quoted "debug"} \(Loaded from: initial\)/,
         /  loggingEndpoint: #{quoted("https://appsignal-endpoint.net")}/,
-        /  name: #{quoted "DiagnoseTests"} \(Loaded from: env\)/,
+        /  name: #{quoted "DiagnoseTests"}/,
+        /    Sources:/,
+        /      env:     #{quoted "DiagnoseTests"}/,
+        /      initial: #{quoted "DiagnoseTests"}/,
         /  pushApiKey: #{quoted "test"} \(Loaded from: env\)/,
         /  requestHeaders: \["accept","accept-charset","accept-encoding","accept-language","cache-control","connection","content-length","range"\]/, # rubocop:disable Layout/LineLength
         /  sendEnvironmentMetadata: true/,
@@ -550,7 +557,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         }
       when :nodejs
         {
-          "active" => false,
+          "active" => true,
           "ca_file_path" => ending_with("cert/cacert.pem"),
           "disable_default_instrumentations" => false,
           "dns_servers" => [],
@@ -567,6 +574,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "ignore_errors" => [],
           "ignore_namespaces" => [],
           "log" => "file",
+          "log_level" => "debug",
           "logging_endpoint" => "https://appsignal-endpoint.net",
           "name" => "DiagnoseTests",
           "push_api_key" => "test",
@@ -758,7 +766,11 @@ RSpec.describe "Running the diagnose command without any arguments" do
             "push_api_key" => "test",
             "name" => "DiagnoseTests"
           },
-          "initial" => {},
+          "initial" => {
+            "active" => true,
+            "log_level" => "debug",
+            "name" => "DiagnoseTests"
+          },
           "system" => {}
         }
       else

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -405,7 +405,8 @@ class Runner
       super.merge({
         "NODE_ENV" => "development",
         "APPSIGNAL_ENABLE_MINUTELY_PROBES" => "false",
-        "APPSIGNAL_APP_NAME" => "DiagnoseTests"
+        "APPSIGNAL_APP_NAME" => "DiagnoseTests",
+        "APPSIGNAL_DIAGNOSE" => "true"
       })
     end
 


### PR DESCRIPTION
Tests now check config opts coming from the Node.js client initialized in the `appsignal.cjs` files.

Part of: https://github.com/appsignal/appsignal-nodejs/pull/885