### PR TITLE
Add Python diagnose scenarios

### DIFF
--- a/python/__appsignal__.py
+++ b/python/__appsignal__.py
@@ -1,0 +1,5 @@
+from appsignal import Appsignal
+
+appsignal = Appsignal(
+    name="DiagnoseTests",
+)

--- a/python/__appsignal__.py
+++ b/python/__appsignal__.py
@@ -1,5 +1,6 @@
 from appsignal import Appsignal
 
+
 appsignal = Appsignal(
     name="DiagnoseTests",
 )

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  Language: #{@runner.language_name}/,
         /  (Gem|Package) version: #{quoted VERSION_PATTERN}/,
         /  Agent version: #{quoted REVISION_PATTERN}/,
-        /  (Extension|Nif) loaded: true/
+        /  (Extension|Nif) loaded: (t|T)rue/
       ]
     )
   end

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -9,7 +9,7 @@ TAR_FILENAME_PATTERN =
   /appsignal-#{ARCH_PATTERN}-#{TARGET_PATTERN}-all-#{LIBRARY_TYPE_PATTERN}.tar.gz/
 DOWNLOAD_URL = %r{https://appsignal-agent-releases.global.ssl.fastly.net/#{REVISION_PATTERN}/#{TAR_FILENAME_PATTERN}}
 DATETIME_PATTERN = /\d{4}-\d{2}-\d{2}[ |T]\d{2}:\d{2}:\d{2}( ?UTC|.\d+Z)?/
-TRUE_OR_FALSE_PATTERN = /true|false/
+TRUE_OR_FALSE_PATTERN = /(t|T)rue|(f|F)alse/
 PATH_PATTERN = %r{[/\w.-]+}
 LOG_LINE_PATTERN = /^(#.+|\[#{DATETIME_PATTERN} \(\w+\) \#\d+\]\[\w+\])/
 

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -1204,6 +1204,8 @@ RSpec.describe "Running the diagnose command without install report file" do
   end
 
   it "prints handled errors instead of the report" do
+    skip if @runner.type == :python
+
     matchers = ["Extension installation report"]
     case @runner.type
     when :ruby, :nodejs, :python
@@ -1226,6 +1228,8 @@ RSpec.describe "Running the diagnose command without install report file" do
   end
 
   it "submitted report contains install report errors" do
+    skip if @runner.type == :python
+
     matchers =
       case @runner.type
       when :nodejs
@@ -1283,28 +1287,51 @@ RSpec.describe "Running the diagnose command without Push API key" do
   end
 
   it "prints agent diagnose section with errors" do
+    expected_output = if @runner.type == :python
+                        [
+                          /Agent diagnostics/,
+                          /  Extension tests/,
+                          /  Configuration: invalid/,
+                          /     Error: RequiredEnvVarNotPresent\("APPSIGNAL_PUSH_API_KEY"\)/,
+                          /  Agent tests/,
+                          /    Started: started/,
+                          /    Process user id: \d+/,
+                          /    Process user group id: \d+/,
+                          /    Configuration: invalid/,
+                          /    Logger: not started/,
+                          /    Working directory user id: False/,
+                          /    Working directory user group id: False/,
+                          /    Working directory permissions: False/,
+                          /    Lock path: not writable/
+                        ]
+                      else
+                        [
+                          /Agent diagnostics/,
+                          /  Extension tests/,
+                          /  Configuration: invalid/,
+                          /     Error: RequiredEnvVarNotPresent\("_APPSIGNAL_PUSH_API_KEY"\)/,
+                          /  Agent tests/,
+                          /    Started: -/,
+                          /    Process user id: -/,
+                          /    Process user group id: -/,
+                          /    Configuration: -/,
+                          /    Logger: -/,
+                          /    Working directory user id: -/,
+                          /    Working directory user group id: -/,
+                          /    Working directory permissions: -/,
+                          /    Lock path: -/
+                        ]
+                      end
+
     expect_output_for(
       :agent,
-      [
-        /Agent diagnostics/,
-        /  Extension tests/,
-        /  Configuration: invalid/,
-        /     Error: RequiredEnvVarNotPresent\("_APPSIGNAL_PUSH_API_KEY"\)/,
-        /  Agent tests/,
-        /    Started: -/,
-        /    Process user id: -/,
-        /    Process user group id: -/,
-        /    Configuration: -/,
-        /    Logger: -/,
-        /    Working directory user id: -/,
-        /    Working directory user group id: -/,
-        /    Working directory permissions: -/,
-        /    Lock path: -/
-      ]
+      expected_output
     )
   end
 
   it "submitted report contains agent diagnostics errors" do
+    skip if @runner.type == :python
+
     expect_report_for(
       :agent,
       "extension" => {

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -450,6 +450,26 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  skip_session_data: false/,
         /  transaction_debug_mode: false/
       ]
+    when :python
+      matchers += [
+        /  ca_file_path: #{quoted ".+/src/appsignal/resources/cacert.pem"}/,
+        /  diagnose_endpoint: #{quoted "http:\/\/localhost:4005\/diag"}/,
+        /  enable_host_metrics: True/,
+        /  enable_nginx_metrics: False/,
+        /  enable_statsd: False/,
+        /  environment: #{quoted "development"}/,
+        /  endpoint: #{quoted ENV["APPSIGNAL_PUSH_API_ENDPOINT"]}/,
+        /  files_world_accessible: True/,
+        /  log: #{quoted "file"}/,
+        /  log_level: #{quoted "info"}/,
+        /  send_environment_metadata: True/,
+        /  send_params: True/,
+        /  send_session_data: True/,
+        /  request_headers: \['accept', 'accept-charset', 'accept-encoding', 'accept-language', 'cache-control', 'connection', 'content-length', 'range'\]/, # rubocop:disable Layout/LineLength
+        /  app_path:/,
+        /  name: #{quoted "DiagnoseTests"}/,
+        /  push_api_key: #{quoted "test"}/,
+      ]
     else
       raise "No clause for runner #{@runner}"
     end

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -42,32 +42,31 @@ RSpec.describe "Running the diagnose command without any arguments" do
   end
 
   it "prints all sections in the correct order" do
-    section_keys =
-      [
+    section_keys = [
         :header,
         :library,
-        :installation,
+        (:installation unless @runner.type == :python),
         :host,
         :agent,
         :config,
         :validation,
         :paths,
         :send_report
-      ]
+      ].compact
     expect(@runner.output.sections.keys).to eq(section_keys), @runner.output.to_s
   end
 
   it "submitted report contains all keys" do
-    expect(@received_report.to_h.keys).to contain_exactly(
+    expect(@received_report.to_h.keys).to contain_exactly(*[
       "agent",
       "config",
       "host",
-      "installation",
+      ("installation" unless @runner.type == :python),
       "library",
       "paths",
       "process",
       "validation"
-    )
+    ].compact)
   end
 
   it "prints no 'other' section" do

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -255,9 +255,13 @@ RSpec.describe "Running the diagnose command without any arguments" do
     ]
     matchers << /  OTP version: #{quoted(/\d+/)}/ if @runner.type == :elixir
     matchers += [
-      /  Root user: #{TRUE_OR_FALSE_PATTERN}/,
-      /  Running in container: #{TRUE_OR_FALSE_PATTERN}/
+      /  Root user: #{TRUE_OR_FALSE_PATTERN}/
     ]
+    if @runner.type != :python
+      matchers += [
+        /  Running in container: #{TRUE_OR_FALSE_PATTERN}/
+      ]
+    end
     expect_output_for(:host, matchers)
   end
 
@@ -268,8 +272,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
       "language_version" => VERSION_PATTERN,
       "os" => TARGET_PATTERN,
       "os_distribution" => kind_of(String),
-      "root" => false,
-      "running_in_container" => boolean
+      "root" => false
     }
     matchers =
       case @runner.type
@@ -277,6 +280,12 @@ RSpec.describe "Running the diagnose command without any arguments" do
         default_fields.merge("otp_version" => matching(/\d+/))
       else
         default_fields
+      end
+    matchers =
+      if @runner.type == :python
+        matchers
+      else
+        matchers.merge("running_in_container" => boolean)
       end
     expect_report_for(:host, matchers)
   end

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -112,6 +112,8 @@ RSpec.describe "Running the diagnose command without any arguments" do
   end
 
   it "prints the extension installation section" do
+    skip if @runner.type == :python
+
     matchers = [
       "Extension installation report",
       /  Installation result/,
@@ -166,6 +168,8 @@ RSpec.describe "Running the diagnose command without any arguments" do
   end
 
   it "submitted report contains extension installation section" do
+    skip if @runner.type == :python
+
     extra_language =
       case @runner.type
       when :elixir

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -88,25 +88,42 @@ RSpec.describe "Running the diagnose command without any arguments" do
   end
 
   it "prints the library section" do
+    expected_output = if @runner.type == :python
+                        [
+                          /AppSignal library/,
+                          /  Language: #{@runner.language_name}/,
+                          /  (Gem|Package) version: #{quoted VERSION_PATTERN}/,
+                          /  Agent version: #{quoted REVISION_PATTERN}/
+                        ]
+                      else
+                        [
+                          /AppSignal library/,
+                          /  Language: #{@runner.language_name}/,
+                          /  (Gem|Package) version: #{quoted VERSION_PATTERN}/,
+                          /  Agent version: #{quoted REVISION_PATTERN}/,
+                          /  (Extension|Nif) loaded: (t|T)rue/
+                        ]
+                      end
+
     expect_output_for(
       :library,
-      [
-        /AppSignal library/,
-        /  Language: #{@runner.language_name}/,
-        /  (Gem|Package) version: #{quoted VERSION_PATTERN}/,
-        /  Agent version: #{quoted REVISION_PATTERN}/,
-        /  (Extension|Nif) loaded: (t|T)rue/
-      ]
+      expected_output
     )
   end
 
   it "submitted report contains library section" do
-    expect_report_for(
-      :library,
+    expected_output = {
       "language" => @runner.type.to_s,
       "agent_version" => REVISION_PATTERN,
       "package_version" => VERSION_PATTERN,
       "extension_loaded" => true
+    }
+
+    expected_output.delete("extension_loaded") if @runner.type == :python
+
+    expect_report_for(
+      :library,
+      expected_output
     )
   end
 
@@ -265,23 +282,41 @@ RSpec.describe "Running the diagnose command without any arguments" do
   end
 
   it "prints the agent diagnostics section" do
+    expected_output = if @runner.type == :python
+                        [
+                          /Agent diagnostics/,
+                          /  Agent tests/,
+                          /    Started: started/,
+                          /    Process user id: \d+/,
+                          /    Process user group id: \d+/,
+                          /    Configuration: valid/,
+                          /    Logger: started/,
+                          /    Working directory user id: \d+/,
+                          /    Working directory user group id: \d+/,
+                          /    Working directory permissions: \d+/,
+                          /    Lock path: writable/
+                        ]
+                      else
+                        [
+                          /Agent diagnostics/,
+                          /  Extension tests/,
+                          /    Configuration: valid/,
+                          /  Agent tests/,
+                          /    Started: started/,
+                          /    Process user id: \d+/,
+                          /    Process user group id: \d+/,
+                          /    Configuration: valid/,
+                          /    Logger: started/,
+                          /    Working directory user id: \d+/,
+                          /    Working directory user group id: \d+/,
+                          /    Working directory permissions: \d+/,
+                          /    Lock path: writable/
+                        ]
+                      end
+
     expect_output_for(
       :agent,
-      [
-        /Agent diagnostics/,
-        /  Extension tests/,
-        /    Configuration: valid/,
-        /  Agent tests/,
-        /    Started: started/,
-        /    Process user id: \d+/,
-        /    Process user group id: \d+/,
-        /    Configuration: valid/,
-        /    Logger: started/,
-        /    Working directory user id: \d+/,
-        /    Working directory user group id: \d+/,
-        /    Working directory permissions: \d+/,
-        /    Lock path: writable/
-      ]
+      expected_output
     )
   end
 
@@ -1290,14 +1325,12 @@ RSpec.describe "Running the diagnose command without Push API key" do
     expected_output = if @runner.type == :python
                         [
                           /Agent diagnostics/,
-                          /  Extension tests/,
-                          /  Configuration: invalid/,
-                          /     Error: RequiredEnvVarNotPresent\("APPSIGNAL_PUSH_API_KEY"\)/,
                           /  Agent tests/,
                           /    Started: started/,
                           /    Process user id: \d+/,
                           /    Process user group id: \d+/,
                           /    Configuration: invalid/,
+                          /       Error: RequiredEnvVarNotPresent\("APPSIGNAL_PUSH_API_KEY"\)/,
                           /    Logger: not started/,
                           /    Working directory user id: False/,
                           /    Working directory user group id: False/,

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -1043,7 +1043,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
 
     matchers =
       case @runner.type
-      when :elixir
+      when :elixir, :python
         default_paths
       when :nodejs
         default_paths.merge(
@@ -1206,7 +1206,7 @@ RSpec.describe "Running the diagnose command without install report file" do
   it "prints handled errors instead of the report" do
     matchers = ["Extension installation report"]
     case @runner.type
-    when :ruby, :nodejs
+    when :ruby, :nodejs, :python
       matchers += [
         "  Error found while parsing the report.",
         /^  Error: .* [nN]o such file or directory.*install\.report/

--- a/spec/support/diagnose_report_helper.rb
+++ b/spec/support/diagnose_report_helper.rb
@@ -7,6 +7,9 @@ module DiagnoseReportHelper
     end
 
     section = @received_report.section(*section_keys)
+
+    pp section.to_h
+
     expect(section).to match(expected)
   end
 

--- a/spec/support/diagnose_report_helper.rb
+++ b/spec/support/diagnose_report_helper.rb
@@ -8,8 +8,6 @@ module DiagnoseReportHelper
 
     section = @received_report.section(*section_keys)
 
-    pp section.to_h
-
     expect(section).to match(expected)
   end
 

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -496,7 +496,12 @@ class Runner
     end
 
     def ignored_lines
-      ["Checking dependencies"]
+      [
+        /Creating environment: default/,
+        /Installing project in development mode/,
+        /Checking dependencies/,
+        /Syncing dependencies/
+      ]
     end
 
     def type

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -485,6 +485,12 @@ class Runner
       File.join(project_path, "python")
     end
 
+    def run_env
+      super.merge({
+        "APPSIGNAL_APP_NAME" => "DiagnoseTests",
+      })
+    end
+
     def run_command(arguments)
       "hatch run appsignal diagnose"
     end

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -493,7 +493,7 @@ class Runner
     end
 
     def run_command(arguments)
-      "hatch run appsignal diagnose"
+      "hatch run appsignal diagnose #{arguments.join(" ")}"
     end
 
     def ignored_lines

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -484,5 +484,9 @@ class Runner
     def directory
       File.join(project_path, "python")
     end
+
+    def run_command(arguments)
+      "hatch run appsignal diagnose"
+    end
   end
 end

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -479,4 +479,10 @@ class Runner
       REPORT
     end
   end
+
+  class Python < Runner
+    def directory
+      File.join(project_path, "python")
+    end
+  end
 end

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -488,7 +488,7 @@ class Runner
     def run_env
       super.merge({
         "APPSIGNAL_APP_NAME" => "DiagnoseTests",
-        "APPSIGNAL_APP_ENV" => "development",
+        "APPSIGNAL_APP_ENV" => "development"
       })
     end
 

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -488,5 +488,17 @@ class Runner
     def run_command(arguments)
       "hatch run appsignal diagnose"
     end
+
+    def ignored_lines
+      []
+    end
+
+    def type
+      :python
+    end
+
+    def language_name
+      "Python"
+    end
   end
 end

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -490,7 +490,7 @@ class Runner
     end
 
     def ignored_lines
-      []
+      ["Checking dependencies"]
     end
 
     def type

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -488,6 +488,7 @@ class Runner
     def run_env
       super.merge({
         "APPSIGNAL_APP_NAME" => "DiagnoseTests",
+        "APPSIGNAL_APP_ENV" => "development",
       })
     end
 

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -509,6 +509,10 @@ class Runner
       :python
     end
 
+    def after_setup
+      File.write("/tmp/appsignal.log", appsignal_log)
+    end
+
     def language_name
       "Python"
     end

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -95,7 +95,7 @@ class Runner
   end
 
   def run_command(_arguments)
-    raise NotImplementedError("`Runner` subclasses must implement `run_command`")
+    raise NotImplementedError, "`Runner` subclasses must implement `run_command`"
   end
 
   def run # rubocop:disable Metrics/MethodLength

--- a/spec/support/runner_helper.rb
+++ b/spec/support/runner_helper.rb
@@ -4,7 +4,8 @@ module RunnerHelper
   LANGUAGE_RUNNERS = {
     "ruby" => Runner::Ruby,
     "elixir" => Runner::Elixir,
-    "nodejs" => Runner::Nodejs
+    "nodejs" => Runner::Nodejs,
+    "python" => Runner::Python
   }.freeze
 
   def init_runner(options = {})


### PR DESCRIPTION
This PR includes the necessary changes to run the diagnose integration tests in the Python integration.

Python's diagnose command PR: https://github.com/appsignal/appsignal-python/pull/89