### PR TITLE
Fix formatting for Python agent tests

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -1340,11 +1340,11 @@ RSpec.describe "Running the diagnose command without Push API key" do
                           /    Process user group id: \d+/,
                           /    Configuration: invalid/,
                           /       Error: RequiredEnvVarNotPresent\("APPSIGNAL_PUSH_API_KEY"\)/,
-                          /    Logger: not started/,
-                          /    Working directory user id: False/,
-                          /    Working directory user group id: False/,
-                          /    Working directory permissions: False/,
-                          /    Lock path: not writable/
+                          /    Logger: -/,
+                          /    Working directory user id: -/,
+                          /    Working directory user group id: -/,
+                          /    Working directory permissions: -/,
+                          /    Lock path: -/
                         ]
                       else
                         [


### PR DESCRIPTION
It would print things like `False`, `not started`, and `not writable` for tests that weren't present. This doesn't mean they are not writable, only that we couldn't test it. Most likely because the config wasn't loaded and it didn't know what paths to check.

Fix the format to match the other integrations and print a dash instead.

Part of https://github.com/appsignal/appsignal-python/pull/108