### PR TITLE
Add configuration modifiers to Ruby report

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -420,7 +420,10 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  send_environment_metadata: true/,
         /  send_params: true/,
         /  send_session_data: true/,
-        /  transaction_debug_mode: false/
+        /  transaction_debug_mode: false/,
+        "",
+        /Configuration modifiers/,
+        /  APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR: ""/
       ]
     when :nodejs
       matchers += [


### PR DESCRIPTION
Since PR https://github.com/appsignal/appsignal-ruby/pull/991 we have a configuration load modifier that does not active the Ruby gem when this modifier is set.
Update the spec to check for its output.