### PR TITLE
Update Python diagnose env format assertion

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -1348,7 +1348,7 @@ RSpec.describe "Running the diagnose command without Push API key" do
                           /    Process user id: \d+/,
                           /    Process user group id: \d+/,
                           /    Configuration: invalid/,
-                          /       Error: RequiredEnvVarNotPresent\("APPSIGNAL_PUSH_API_KEY"\)/,
+                          /       Error: RequiredEnvVarNotPresent\("_APPSIGNAL_PUSH_API_KEY"\)/,
                           /    Logger: -/,
                           /    Working directory user id: -/,
                           /    Working directory user group id: -/,


### PR DESCRIPTION
Use the private underscored env var for the assertion. It configures the agent using private env vars.

Part of PR https://github.com/appsignal/appsignal-python/pull/150

[skip review]