### PR TITLE
Assert all path details for Node.js integration

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -980,24 +980,16 @@ RSpec.describe "Running the diagnose command without any arguments" do
 
     matchers += [
       %(  Current working directory),
-      /    Path: #{quoted(PATH_PATTERN)}/
+      /    Path: #{quoted(PATH_PATTERN)}/,
+      /    Writable\?: #{TRUE_OR_FALSE_PATTERN}/,
+      /    Ownership\?: #{TRUE_OR_FALSE_PATTERN} \(file: (\w+:)?\d+, process: (\w+:)?\d+/,
+      ""
     ]
-    if [:ruby, :elixir, :python].include? @runner.type
-      matchers += [
-        /    Writable\?: #{TRUE_OR_FALSE_PATTERN}/,
-        /    Ownership\?: #{TRUE_OR_FALSE_PATTERN} \(file: (\w+:)?\d+, process: (\w+:)?\d+/
-      ]
-    end
-    matchers += [""]
 
     if @runner.type == :ruby
       matchers += [
         %(  Root path),
-        /    Path: #{quoted(PATH_PATTERN)}/
-      ]
-    end
-    if [:ruby, :elixir, :python].include? @runner.type
-      matchers += [
+        /    Path: #{quoted(PATH_PATTERN)}/,
         /    Writable\?: #{TRUE_OR_FALSE_PATTERN}/,
         /    Ownership\?: #{TRUE_OR_FALSE_PATTERN} \(file: (\w+:)?\d+, process: (\w+:)?\d+/,
         ""
@@ -1006,20 +998,18 @@ RSpec.describe "Running the diagnose command without any arguments" do
 
     matchers += [
       %(  Log directory),
-      /    Path: #{quoted(PATH_PATTERN)}/
+      /    Path: #{quoted(PATH_PATTERN)}/,
+      /    Writable\?: #{TRUE_OR_FALSE_PATTERN}/,
+      /    Ownership\?: #{TRUE_OR_FALSE_PATTERN} \(file: (\w+:)?\d+, process: (\w+:)?\d+/,
+      ""
     ]
-    if [:ruby, :elixir, :python].include? @runner.type
-      matchers += [
-        /    Writable\?: #{TRUE_OR_FALSE_PATTERN}/,
-        /    Ownership\?: #{TRUE_OR_FALSE_PATTERN} \(file: (\w+:)?\d+, process: (\w+:)?\d+/
-      ]
-    end
-    matchers += [""]
 
     if @runner.type == :nodejs
       matchers += [
         %(  AppSignal client file),
         /    Path: #{quoted(PATH_PATTERN)}/,
+        /    Writable\?: #{TRUE_OR_FALSE_PATTERN}/,
+        /    Ownership\?: #{TRUE_OR_FALSE_PATTERN} \(file: (\w+:)?\d+, process: (\w+:)?\d+/,
         ""
       ]
     end
@@ -1033,17 +1023,11 @@ RSpec.describe "Running the diagnose command without any arguments" do
       ]
     end
 
-    matchers += [
-      %(  AppSignal log),
-      /    Path: #{quoted(PATH_PATTERN)}/
-    ]
-    if [:ruby, :elixir, :python].include? @runner.type
-      matchers += [
-        /    Writable\?: #{TRUE_OR_FALSE_PATTERN}/,
-        /    Ownership\?: #{TRUE_OR_FALSE_PATTERN} \(file: (\w+:)?\d+, process: (\w+:)?\d+/
-      ]
-    end
     matchers += ([
+      %(  AppSignal log),
+      /    Path: #{quoted(PATH_PATTERN)}/,
+      /    Writable\?: #{TRUE_OR_FALSE_PATTERN}/,
+      /    Ownership\?: #{TRUE_OR_FALSE_PATTERN} \(file: (\w+:)?\d+, process: (\w+:)?\d+/,
       /    Contents \(last 10 lines\):/
     ] + Array.new(10).map { LOG_LINE_PATTERN })
 


### PR DESCRIPTION
The Node.js integration was the only integration that didn't list these path details, but now it does.

Needed for https://github.com/appsignal/appsignal-nodejs/pull/958