### PR TITLE
Update Ruby gem Makefile log path key assertion

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -1103,7 +1103,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         default_paths.merge(
           "ext/mkmf.log" => {
             "exists" => false,
-            "path" => ending_with("ext/mkmf.log")
+            "path" => ending_with("mkmf.log")
           },
           "package_install_path" => { # TODO: Add this to Elixir and Node.js as well
             "exists" => true,


### PR DESCRIPTION
The path for the `mkmf.log` file has changed. It's no longer expected to be in a `ext/` sub dir. It's in a completely different dir. This is better tested in the Ruby gem itself.

Related PR: https://github.com/appsignal/appsignal-ruby/pull/1022
Related issue: https://github.com/appsignal/appsignal-ruby/issues/1018