### PR TITLE
Update Ruby headers default values

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  logging_endpoint: #{quoted("https://appsignal-endpoint.net")}/,
         /  name: #{quoted "DiagnoseTests"} \(Loaded from: file\)/,
         /  push_api_key: "test" \(Loaded from: env\)/,
-        /  request_headers: \["HTTP_ACCEPT", "HTTP_ACCEPT_CHARSET", "HTTP_ACCEPT_ENCODING", "HTTP_ACCEPT_LANGUAGE", "HTTP_CACHE_CONTROL", "HTTP_CONNECTION", "CONTENT_LENGTH", "PATH_INFO", "HTTP_RANGE", "REQUEST_METHOD", "REQUEST_URI", "SERVER_NAME", "SERVER_PORT", "SERVER_PROTOCOL"\]/, # rubocop:disable Layout/LineLength
+        /  request_headers: \["HTTP_ACCEPT", "HTTP_ACCEPT_CHARSET", "HTTP_ACCEPT_ENCODING", "HTTP_ACCEPT_LANGUAGE", "HTTP_CACHE_CONTROL", "HTTP_CONNECTION", "CONTENT_LENGTH", "PATH_INFO", "HTTP_RANGE", "REQUEST_METHOD", "REQUEST_PATH", "SERVER_NAME", "SERVER_PORT", "SERVER_PROTOCOL"\]/, # rubocop:disable Layout/LineLength
         /  send_environment_metadata: true/,
         /  send_params: true/,
         /  send_session_data: true/,
@@ -583,7 +583,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
             "PATH_INFO",
             "HTTP_RANGE",
             "REQUEST_METHOD",
-            "REQUEST_URI",
+            "REQUEST_PATH",
             "SERVER_NAME",
             "SERVER_PORT",
             "SERVER_PROTOCOL"
@@ -758,7 +758,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
               "PATH_INFO",
               "HTTP_RANGE",
               "REQUEST_METHOD",
-              "REQUEST_URI",
+              "REQUEST_PATH",
               "SERVER_NAME",
               "SERVER_PORT",
               "SERVER_PROTOCOL"


### PR DESCRIPTION
REQUEST_URI is no longer a default header this commit changes it to REQUEST_PATH

Part of: https://github.com/appsignal/appsignal-ruby/issues/1038