### PR TITLE
Read config improvements

### DIFF
--- a/bin/test-all
+++ b/bin/test-all
@@ -9,8 +9,9 @@ INTEGRATIONS_FOLDER="${INTEGRATIONS_FOLDER:-".."}"
 export RUBY_INTEGRATION_PATH="${RUBY_INTEGRATION_PATH:-"${INTEGRATIONS_FOLDER}/appsignal-ruby"}"
 export ELIXIR_INTEGRATION_PATH="${ELIXIR_INTEGRATION_PATH:-"${INTEGRATIONS_FOLDER}/appsignal-elixir"}"
 export NODEJS_INTEGRATION_PATH="${NODEJS_INTEGRATION_PATH:-"${INTEGRATIONS_FOLDER}/appsignal-nodejs"}"
+export PYTHON_INTEGRATION_PATH="${PYTHON_INTEGRATION_PATH:-"${INTEGRATIONS_FOLDER}/appsignal-python"}"
 
-for language in "ruby" "elixir" "nodejs"; do
+for language in "ruby" "elixir" "nodejs" "python"; do
   echo
   echo "Run $language suite"
   echo "========"

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -502,7 +502,7 @@ class Runner
         /Installing project in development mode/,
         /Checking dependencies/,
         /Syncing dependencies/,
-        /Could not load the configuration from the `__appsignal__.py` configuration file/,
+        /Could not load the configuration from the `__appsignal__.py` configuration file/
       ]
     end
 

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -501,7 +501,8 @@ class Runner
         /Creating environment: default/,
         /Installing project in development mode/,
         /Checking dependencies/,
-        /Syncing dependencies/
+        /Syncing dependencies/,
+        /Could not load the configuration from the `__appsignal__.py` configuration file/,
       ]
     end
 


### PR DESCRIPTION
Context: https://github.com/appsignal/appsignal-python/pull/196

### [Ignore warning about the configuration file](https://github.com/appsignal/diagnose_tests/commit/e46ca089b5979aaa3a572c4eade278637c18cec0)

A warning is raised about not being able to find the configuration
file. Ignore it.

### [Add Python to the test all script](https://github.com/appsignal/diagnose_tests/commit/c9cbf0d7a16d8f5d86a7ee2218dec7d4fe10365d)

On the script that tests against all languages, add support for
Python alongside the other languages.