### PR TITLE
Fix Python diagnose working dir and initial config

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -691,7 +691,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         }
       when :python
         {
-          "app_path" => ending_with("appsignal-python"),
+          "app_path" => ending_with("diagnose/python"),
           "ca_file_path" => ending_with("resources/cacert.pem"),
           "diagnose_endpoint" => ending_with("diag"),
           "enable_host_metrics" => true,
@@ -939,8 +939,8 @@ RSpec.describe "Running the diagnose command without any arguments" do
              "connection",
              "content-length",
              "range"] },
-          "system" => { "app_path" => ending_with("appsignal-python") },
-          "initial" => {},
+          "system" => { "app_path" => ending_with("diagnose/python") },
+          "initial" => { "name" => "DiagnoseTests" },
           "environment" =>
           { "diagnose_endpoint" => ending_with("diag"),
             "enable_minutely_probes" => false,

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -502,8 +502,7 @@ class Runner
         /Creating environment: default/,
         /Installing project in development mode/,
         /Checking dependencies/,
-        /Syncing dependencies/,
-        /Could not load the configuration from the `__appsignal__.py` configuration file/
+        /Syncing dependencies/
       ]
     end
 


### PR DESCRIPTION
In a recent version of hatch, they made sure the working directory stays the same for `hatch run`. It will now be the directory in which the `hatch run` was run, not be the project directory of the package you're running.

Update the paths to match the working directory of the diagnose tests submodule.

Now that it uses the correct working directory, it also loads the `__appsignal__.py` config file correctly, so update the initial config source content. Remove the ignored line that hid this issue.

[skip review]