### PR TITLE
Enable First*ElementLineBreak RuboCop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,9 +16,6 @@ Style/StringLiteralsInInterpolation:
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
-Layout/HashAlignment:
-  EnforcedLastArgumentHashStyle: ignore_implicit
-
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 
@@ -30,6 +27,12 @@ Layout/MultilineMethodCallIndentation:
 
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -913,8 +913,9 @@ RSpec.describe "Running the diagnose command without any arguments" do
           "system" => {}
         }
       when :python
-        { "default" =>
-          { "ca_file_path" => ending_with("resources/cacert.pem"),
+        {
+          "default" => {
+            "ca_file_path" => ending_with("resources/cacert.pem"),
             "diagnose_endpoint" => ending_with("diag"),
             "enable_host_metrics" => true,
             "enable_minutely_probes" => true,
@@ -930,24 +931,28 @@ RSpec.describe "Running the diagnose command without any arguments" do
             "send_environment_metadata" => true,
             "send_params" => true,
             "send_session_data" => true,
-            "request_headers" =>
-            ["accept",
-             "accept-charset",
-             "accept-encoding",
-             "accept-language",
-             "cache-control",
-             "connection",
-             "content-length",
-             "range"] },
+            "request_headers" => [
+              "accept",
+              "accept-charset",
+              "accept-encoding",
+              "accept-language",
+              "cache-control",
+              "connection",
+              "content-length",
+              "range"
+            ]
+          },
           "system" => { "app_path" => ending_with("diagnose/python") },
           "initial" => { "name" => "DiagnoseTests" },
-          "environment" =>
-          { "diagnose_endpoint" => ending_with("diag"),
+          "environment" => {
+            "diagnose_endpoint" => ending_with("diag"),
             "enable_minutely_probes" => false,
             "endpoint" => ENV.fetch("APPSIGNAL_PUSH_API_ENDPOINT", nil),
             "environment" => "development",
             "name" => "DiagnoseTests",
-            "push_api_key" => "test" } }
+            "push_api_key" => "test"
+          }
+        }
       else
         raise "No clause for runner #{@runner}"
       end


### PR DESCRIPTION
Last change I found it difficult to follow when the modified hash and arrays in this commit ended. There were a bunch of `}` on one line.

Enable rules to enforce the first key/value in a hash or array always start on a new line in multi line definitions.

[skip reviewo