### PR TITLE
Fix runner for Ruby setup on GitHub Actions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,9 @@ Style/SymbolArray:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - Rakefile

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ../../../..
   specs:
-    appsignal (3.0.15)
+    appsignal (3.9.2)
       rack
 
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (2.2.3)
+    rack (3.1.5)
 
 PLATFORMS
   ruby

--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  activejob_report_errors: "all"/,
         %r{  ca_file_path: ".+/appsignal[-/]ruby/resources/cacert.pem"},
         /  debug: false/,
-        /  dns_servers: \[\]/,
+        "  dns_servers: []",
         /  enable_allocation_tracking: true/,
         /  enable_gvl_global_timer: true/,
         /  enable_gvl_waiting_threads: true/,
@@ -472,7 +472,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /      system:  true/,
         /  ca_file_path: #{quoted ".+/_build/dev/rel/elixir_diagnose/lib/appsignal-\\d+\\.\\d+\\.\\d+(-\\w+\\.\\d+)?/priv/cacert.pem"}/, # rubocop:disable Layout/LineLength
         /  debug: false/,
-        /  dns_servers: \[\]/,
+        "  dns_servers: []",
         /  enable_error_backend: true/,
         /  enable_host_metrics: true/,
         /  enable_minutely_probes: false/,

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -191,6 +191,13 @@ class Runner
       File.join(project_path, "ruby")
     end
 
+    def setup_commands
+      [
+        "bundle config set --local gemfile #{directory}/Gemfile",
+        "bundle install"
+      ]
+    end
+
     def run_env
       super.merge({
         "BUNDLE_GEMFILE" => File.join(directory, "Gemfile")

--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -205,7 +205,8 @@ class Runner
 
     def ignored_lines
       [
-        /appsignal: Unable to log to /
+        /appsignal: Unable to log to /,
+        /Calling `DidYouMean::SPELL_CHECKERS/
       ]
     end
 


### PR DESCRIPTION
## Fix diagnose output matcher

I got this error when performing this spec. Match a String instead so the error goes away.

> RegexpError: empty char-class

## Ignore DidYouMean output in the Ruby runner

It would fail on this line of output being present, so ignore it.

## Explicitly run bundle install for Ruby runner

Not sure how it worked before, but explicitly install the runner's gems from the Gemfile, which includes the Ruby gem it's testing. I ran into errors of the gem not being found.

## Fix bundler env being copied to Ruby runner

Fix issues with the wrong bundle of gems being used as context for the runner. This failed to find the Ruby gem as it was using this project's test suite Gemfile instead.

Wrap commands with `Bundler.with_unbundled_env` so it removes any Bundler context from the environment. It also clears some other env vars, so explicitly set them again in the base `run_env` method.
