### PR TITLE
Remove Ruby config modifiers

### DIFF
--- a/spec/diagnose_spec.rb
+++ b/spec/diagnose_spec.rb
@@ -414,10 +414,7 @@ RSpec.describe "Running the diagnose command without any arguments" do
         /  send_environment_metadata: true/,
         /  send_params: true/,
         /  send_session_data: true/,
-        /  sidekiq_report_errors: "all"/,
-        "",
-        /Configuration modifiers/,
-        /  APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR: ""/
+        /  sidekiq_report_errors: "all"/
       ]
     when :nodejs
       matchers += [


### PR DESCRIPTION
This behavior was removed from Ruby gem 4.

Part of https://github.com/appsignal/appsignal-ruby/pull/1224

[skip review]