### PR TITLE
Ignore Python deprecation warning

### DIFF
--- a/spec/support/runner.rb
+++ b/spec/support/runner.rb
@@ -520,7 +520,8 @@ class Runner
         /Creating environment: default/,
         /Installing project in development mode/,
         /Checking dependencies/,
-        /Syncing dependencies/
+        /Syncing dependencies/,
+        /DEPRECATION: --no-python-version-warning is deprecated/
       ]
     end
 


### PR DESCRIPTION
It suddenly started printing this warning. We don't pass this flag that I can see, so ignore the output. It doesn't concern our tests.

[skip review]